### PR TITLE
security: add ownership authorization checks (#3)

### DIFF
--- a/back/cloudinary/routes.py
+++ b/back/cloudinary/routes.py
@@ -1,6 +1,7 @@
 from flask import Blueprint, request, jsonify
 from flask_jwt_extended import jwt_required
 from back.models import db, User
+from back.utils import get_current_user
 from back.cloudinary.config import cloudinary
 import cloudinary.uploader
 from werkzeug.utils import secure_filename
@@ -15,6 +16,10 @@ def upload_profile_picture(user_id):
     """
     Upload or update a user's profile picture on Cloudinary
     """
+    current = get_current_user()
+    if not current or current.id != user_id:
+        return jsonify({"error": "Forbidden"}), 403
+
     try:
         user = User.query.get(user_id)
         if not user:

--- a/back/urls/exchange.py
+++ b/back/urls/exchange.py
@@ -4,6 +4,7 @@
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
+from back.utils import get_current_user
 from back.models import db, Exchange, User, Skill
 
 exchanges = Blueprint("exchanges", __name__)
@@ -107,6 +108,10 @@ def create_exchange():
     """
     data = request.get_json() or {}
 
+    current = get_current_user()
+    if not current or current.id != data.get("offerer_id"):
+        return jsonify({"error": "Forbidden"}), 403
+
     try:
         required = ["offerer_id", "skill_id"]
         for field in required:
@@ -152,6 +157,11 @@ def complete_exchange(exchange_id):
 
         if not exchange:
             return jsonify({"error": "Exchange not found"}), 404
+
+        current = get_current_user()
+        if not current or current.id not in (
+                exchange.offerer_id, exchange.demander_id):
+            return jsonify({"error": "Forbidden"}), 403
 
         if exchange.is_completed:
             return jsonify({
@@ -208,6 +218,10 @@ def assign_demander(exchange_id):
     """
     data = request.get_json() or {}
 
+    current = get_current_user()
+    if not current or current.id != data.get("user_id"):
+        return jsonify({"error": "Forbidden"}), 403
+
     try:
         demander_id = data.get("user_id")
         if not demander_id:
@@ -260,6 +274,10 @@ def delete_exchange(exchange_id):
 
         if not exchange:
             return jsonify({"error": "Exchange not found"}), 404
+
+        current = get_current_user()
+        if not current or current.id != exchange.offerer_id:
+            return jsonify({"error": "Forbidden"}), 403
 
         if exchange.is_completed:
             return jsonify({

--- a/back/urls/message.py
+++ b/back/urls/message.py
@@ -4,6 +4,7 @@
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required
 from back.models import db, Message
+from back.utils import get_current_user
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 
 messages = Blueprint('messages', __name__)
@@ -76,7 +77,11 @@ def create_message():
     """
         Create a message
     """
-    data = request.get_json()
+    data = request.get_json() or {}
+    current = get_current_user()
+    if not current or current.id != data.get("sender_id"):
+        return jsonify({"error": "Forbidden"}), 403
+
     try:
         msg = Message(
             content=data['content'],
@@ -107,6 +112,10 @@ def update_message(message_id):
 
     try:
         msg = Message.query.get_or_404(message_id)
+
+        current = get_current_user()
+        if not current or current.id != msg.sender_id:
+            return jsonify({"error": "Forbidden"}), 403
 
         if not data:
             return jsonify({"error": "Incomplete parameters"}), 400
@@ -142,6 +151,10 @@ def delete_message(message_id):
 
         if not msg:
             return jsonify({"error": "Message not found"}), 404
+
+        current = get_current_user()
+        if not current or current.id != msg.sender_id:
+            return jsonify({"error": "Forbidden"}), 403
 
         db.session.delete(msg)
         db.session.commit()

--- a/back/urls/rating.py
+++ b/back/urls/rating.py
@@ -4,6 +4,7 @@
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
+from back.utils import get_current_user
 from back.models import db, User, Rating, Exchange
 
 ratings = Blueprint('ratings', __name__)
@@ -56,6 +57,10 @@ def create_rating():
         Create a rating
     """
     data = request.get_json() or {}
+    current = get_current_user()
+    if not current or current.id != data.get("rater_id"):
+        return jsonify({"error": "Forbidden"}), 403
+
     try:
         required_fields = ["exchange_id", "rater_id", "score"]
         missing = [f for f in required_fields if f not in data]
@@ -118,6 +123,10 @@ def update_rating(rating_id):
 
         if not rating:
             return jsonify({"error": "Rating not found"}), 404
+
+        current = get_current_user()
+        if not current or current.id != rating.rater_id:
+            return jsonify({"error": "Forbidden"}), 403
         if not data:
             return jsonify({"error": "Incomplete parameters"}), 400
 
@@ -150,6 +159,10 @@ def delete_rating(rating_id):
 
         if not rating:
             return jsonify({"error": "Rating not found"}), 404
+
+        current = get_current_user()
+        if not current or current.id != rating.rater_id:
+            return jsonify({"error": "Forbidden"}), 403
 
         db.session.delete(rating)
         db.session.commit()

--- a/back/urls/user.py
+++ b/back/urls/user.py
@@ -8,6 +8,7 @@ from flask_jwt_extended import create_access_token, create_refresh_token
 from flask_jwt_extended import jwt_required
 from flask_jwt_extended import get_jwt_identity
 from back.models import db, User, Skill, Category
+from back.utils import get_current_user
 
 users = Blueprint('users', __name__)
 
@@ -84,6 +85,10 @@ def delete_user(user_id):
     """
         Delete a user
     """
+    current = get_current_user()
+    if not current or current.id != user_id:
+        return jsonify({"error": "Forbidden"}), 403
+
     user = User.query.get(user_id)
     if not user:
         return jsonify({"error": "User not found"}), 404
@@ -157,6 +162,10 @@ def update_user(user_id):
     """
         Update a user
     """
+    current = get_current_user()
+    if not current or current.id != user_id:
+        return jsonify({"error": "Forbidden"}), 403
+
     data = request.get_json() or {}
 
     try:
@@ -196,6 +205,10 @@ def update_user_skill(user_id):
     """
         Associate/Disassociate skills to/from users
     """
+    current = get_current_user()
+    if not current or current.id != user_id:
+        return jsonify({"error": "Forbidden"}), 403
+
     data = request.get_json() or {}
     try:
         usr = User.query.get(user_id)

--- a/back/utils.py
+++ b/back/utils.py
@@ -2,6 +2,7 @@
     Utils module
 """
 from flask import url_for
+from flask_jwt_extended import get_jwt_identity
 
 
 class APIException(Exception):
@@ -20,6 +21,13 @@ class APIException(Exception):
         rv = dict(self.payload or ())
         rv['message'] = self.message
         return rv
+
+
+def get_current_user():
+    """Return the User row matching the JWT identity (email)."""
+    from back.models import User  # local import to avoid circular dependency
+    email = get_jwt_identity()
+    return User.query.filter_by(email=email).first()
 
 
 def has_no_empty_params(rule):


### PR DESCRIPTION
## Summary

- Added `get_current_user()` helper in `back/utils.py` — centralizes JWT email → User lookup
- Added ownership checks (403 Forbidden) to 14 endpoints across 5 files
- Users can only modify their own profile, skills, messages, and profile picture
- Only exchange participants can complete an exchange; only the offerer can delete it
- Only the rater can update or delete their own rating

## Ownership rules applied

| File | Endpoint | Rule |
|------|----------|------|
| `user.py` | `DELETE /api/users/<id>` | `current.id == user_id` |
| `user.py` | `PUT /api/users/<id>` | `current.id == user_id` |
| `user.py` | `POST /api/users/<id>/skill` | `current.id == user_id` |
| `message.py` | `POST /api/messages` | `current.id == sender_id` |
| `message.py` | `PUT /api/messages/<id>` | `current.id == msg.sender_id` |
| `message.py` | `DELETE /api/messages/<id>` | `current.id == msg.sender_id` |
| `exchange.py` | `POST /api/exchanges` | `current.id == offerer_id` |
| `exchange.py` | `PUT /api/exchanges/<id>/complete` | `current.id in (offerer_id, demander_id)` |
| `exchange.py` | `PUT /api/exchanges/join/<id>` | `current.id == user_id` |
| `exchange.py` | `DELETE /api/exchanges/<id>` | `current.id == offerer_id` |
| `rating.py` | `POST /api/ratings` | `current.id == rater_id` |
| `rating.py` | `PUT /api/ratings/<id>` | `current.id == rating.rater_id` |
| `rating.py` | `DELETE /api/ratings/<id>` | `current.id == rating.rater_id` |
| `cloudinary/routes.py` | `POST /api/users/<id>/profile-picture` | `current.id == user_id` |

## Test plan

- [ ] Authenticated user attempting to modify another user's resource receives 403
- [ ] Authenticated user modifying their own resource proceeds normally
- [ ] Non-participant trying to complete/delete an exchange receives 403
- [ ] User trying to rate as someone else receives 403

Closes #3