### PR TITLE
feat: add refresh token endpoint (#9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ En producción: Nginx sirve el frontend estático (puerto 80) y hace proxy de `/
 | Recurso    | URL base          | Métodos                        |
 |------------|-------------------|--------------------------------|
 | Usuarios   | `/api/users`      | GET, POST, PUT, DELETE         |
-| Auth       | `/api/auth`       | POST `/login`, GET `/me`       |
+| Auth       | `/api/auth`       | POST `/login`, GET `/me`, POST `/refresh` |
 | Habilidades| `/api/skills`     | GET, POST, PUT, DELETE         |
 | Categorías | `/api/categories` | GET, POST, PUT, DELETE         |
 | Mensajes   | `/api/messages`   | GET, POST, PUT, DELETE         |

--- a/back/app.py
+++ b/back/app.py
@@ -56,6 +56,7 @@ print(f" * Database in use: {DB_URL}")
 app.config["SQLALCHEMY_DATABASE_URI"] = DB_URL
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 app.config["JWT_ACCESS_TOKEN_EXPIRES"] = timedelta(hours=6)
+app.config["JWT_REFRESH_TOKEN_EXPIRES"] = timedelta(days=30)
 app.config["SECRET_KEY"] = os.getenv("FLASK_APP_KEY")
 app.config["DEBUG"] = os.getenv("FLASK_DEBUG", "0") == "1"
 

--- a/back/urls/user.py
+++ b/back/urls/user.py
@@ -327,3 +327,14 @@ def get_current_user():
         return jsonify({"error": "User not found"}), 404
 
     return success(user.to_dict())
+
+
+@users.route("/api/auth/refresh", methods=["POST"])
+@jwt_required(refresh=True)
+def refresh():
+    """
+        Issues a new access token using a valid refresh token
+    """
+    email = get_jwt_identity()
+    new_token = create_access_token(identity=email)
+    return success({"token": new_token})

--- a/front/pages/Login.jsx
+++ b/front/pages/Login.jsx
@@ -38,10 +38,13 @@ const Login = () => {
         throw new Error("Error al conectar con el servidor");
       }
       const data = await response.json();
+      const token = data?.data?.token;
+      const refreshToken = data?.data?.refresh_token;
 
-      if (data) {
-        localStorage.setItem("token", JSON.stringify(data?.token));
-        dispatch({ type: "SET_TOKEN", payload: data?.token });
+      if (token) {
+        localStorage.setItem("token", JSON.stringify(token));
+        if (refreshToken) localStorage.setItem("refresh_token", refreshToken);
+        dispatch({ type: "SET_TOKEN", payload: token });
         navigate("/perfil");
       } else {
         setError("Correo o contraseña incorrectos.");

--- a/front/pages/UserProfile.jsx
+++ b/front/pages/UserProfile.jsx
@@ -5,6 +5,7 @@ import Footer from "../assets/components/Footer";
 import "../assets/styles/UserProfile.css";
 import { env } from "../environ";
 import { useStore } from "../hooks/useStore";
+import { apiFetch } from "../services/api";
 import CropperModal from "../assets/components/CropperModal";
 import AddSkillModal from "../assets/components/AddSkillModal";
 import MessagingButton from "../assets/components/MessagingButton";
@@ -87,24 +88,22 @@ function UserProfile() {
 
     const fetchUser = async () => {
       try {
-        const response = await fetch(`${env.api}/api/auth/me`, {
+        const response = await apiFetch(`${env.api}/api/auth/me`, {
           method: "GET",
-          headers: {
-            Authorization: `Bearer ${userToken}`,
-            Accept: "application/json",
-          },
         });
 
         if (!response.ok) {
           localStorage.removeItem("token");
-          console.error("Error al obtener usuario:", response.status);
+          localStorage.removeItem("refresh_token");
+          navigate("/login");
           return;
         }
 
         const data = await response.json();
-        setUser(data);
-        setFormData(data);
-        dispatch({ type: "SET_USER", payload: data });
+        const userData = data?.data;
+        setUser(userData);
+        setFormData(userData);
+        dispatch({ type: "SET_USER", payload: userData });
       } catch (error) {
         console.error("Error al cargar usuario:", error);
       }

--- a/front/services/api.js
+++ b/front/services/api.js
@@ -1,5 +1,88 @@
 import { env } from "../environ";
 
+const getToken = () => {
+  const raw = localStorage.getItem("token");
+  return raw ? raw.replace(/^"|"$/g, "") : null;
+};
+
+let isRefreshing = false;
+let refreshQueue = [];
+
+const processQueue = (error, token = null) => {
+  refreshQueue.forEach((prom) => {
+    if (error) prom.reject(error);
+    else prom.resolve(token);
+  });
+  refreshQueue = [];
+};
+
+export const refreshAccessToken = async () => {
+  const refreshToken = localStorage.getItem("refresh_token");
+  if (!refreshToken) return null;
+
+  try {
+    const response = await fetch(`${env.api}/api/auth/refresh`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${refreshToken}`,
+        Accept: "application/json",
+      },
+    });
+
+    if (!response.ok) {
+      localStorage.removeItem("token");
+      localStorage.removeItem("refresh_token");
+      return null;
+    }
+
+    const data = await response.json();
+    const newToken = data?.data?.token;
+    if (newToken) {
+      localStorage.setItem("token", JSON.stringify(newToken));
+    }
+    return newToken || null;
+  } catch {
+    localStorage.removeItem("token");
+    localStorage.removeItem("refresh_token");
+    return null;
+  }
+};
+
+export const apiFetch = async (url, options = {}) => {
+  const token = getToken();
+  const headers = {
+    Accept: "application/json",
+    ...(options.headers || {}),
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+  };
+
+  const response = await fetch(url, { ...options, headers });
+  if (response.status !== 401) return response;
+
+  // 401 — attempt token refresh
+  if (isRefreshing) {
+    return new Promise((resolve, reject) => {
+      refreshQueue.push({ resolve, reject });
+    }).then((newToken) => {
+      const retryHeaders = { ...headers, Authorization: `Bearer ${newToken}` };
+      return fetch(url, { ...options, headers: retryHeaders });
+    });
+  }
+
+  isRefreshing = true;
+  const newToken = await refreshAccessToken();
+  isRefreshing = false;
+
+  if (!newToken) {
+    processQueue(new Error("Session expired"), null);
+    return response; // return original 401
+  }
+
+  processQueue(null, newToken);
+  const retryHeaders = { ...headers, Authorization: `Bearer ${newToken}` };
+  return fetch(url, { ...options, headers: retryHeaders });
+};
+
 export const registerUser = async (formData) => {
   try {
     const response = await fetch(`${env.api}/api/users`, {


### PR DESCRIPTION
## Summary

- Agrega `POST /api/auth/refresh` con `@jwt_required(refresh=True)` — emite nuevo access token a partir de un refresh token válido
- Configura `JWT_REFRESH_TOKEN_EXPIRES = 30d` explícito en `app.py`
- Corrige `Login.jsx` para leer `data.data.token` (wrapper `success()`) y persistir `refresh_token` en localStorage
- Agrega `refreshAccessToken()` y `apiFetch()` en `services/api.js` con manejo de requests concurrentes (queue)
- Actualiza `UserProfile.jsx` para usar `apiFetch` con refresh automático y redirect a `/login` si la sesión expira

Closes #9

## Test plan

- [ ] Login guarda `refresh_token` en localStorage
- [ ] `POST /api/auth/refresh` con refresh token válido devuelve nuevo access token
- [ ] `POST /api/auth/refresh` con access token (tipo incorrecto) devuelve 422
- [ ] `POST /api/auth/refresh` sin token devuelve 401
- [ ] Borrar `token` de localStorage (mantener `refresh_token`), navegar a `/perfil` — el token se renueva silenciosamente
- [ ] Borrar ambos tokens, navegar a `/perfil` — redirige a `/login`