### PR TITLE
feat: implement Google OAuth with frontend-driven popup flow (#10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 
 ## Tecnologías
 
-- **Frontend**: React 19, React Router 7, Vite 7, Bootstrap 5
-- **Backend**: Flask, SQLAlchemy, Flask-JWT-Extended
+- **Frontend**: React 19, React Router 7, Vite 7, Bootstrap 5, `@react-oauth/google`
+- **Backend**: Flask, SQLAlchemy, Flask-JWT-Extended, `google-auth`
 - **Base de datos**: PostgreSQL 16
 - **Media**: Cloudinary (fotos de perfil)
 - **Despliegue**: Docker Compose (dev & prod), Render, GitHub Container Registry
@@ -28,10 +28,14 @@ cp back/.env.example back/.env
 cp front/.env.example front/.env
 cp db.env.example db.env
 
-# 3. Levantar los servicios
+# 3. Configurar Google OAuth (opcional, necesario para login con Google)
+# En back/.env: GOOGLE_CLIENT_ID=<tu-client-id>.apps.googleusercontent.com
+# En front/.env: VITE_GOOGLE_CLIENT_ID=<tu-client-id>.apps.googleusercontent.com
+
+# 4. Levantar los servicios
 docker compose up --build
 
-# 4. Ejecutar migraciones y seed (en otra terminal)
+# 5. Ejecutar migraciones y seed (en otra terminal)
 docker compose exec backend flask db upgrade
 docker compose exec backend python -m back.init.seed_data
 docker compose exec backend python -m back.init.seed_users
@@ -46,12 +50,16 @@ Los cambios en `back/` y `front/` se reflejan automáticamente (hot-reload).
 ## Producción
 
 ```bash
-# Levantar con Docker
+# Levantar con Docker (VITE_GOOGLE_CLIENT_ID se bake en el build del frontend)
+VITE_GOOGLE_CLIENT_ID=<client-id>.apps.googleusercontent.com \
 docker compose -f compose.prod.yml up --build
 
 # Construir imágenes para el registry
 docker build -f docker/prod/backend.Dockerfile -t ghcr.io/jemartnz/swapp-backend .
-docker build -f docker/prod/frontend.Dockerfile -t ghcr.io/jemartnz/swapp-frontend .
+docker build \
+  --build-arg VITE_GOOGLE_CLIENT_ID=<client-id>.apps.googleusercontent.com \
+  -f docker/prod/frontend.Dockerfile \
+  -t ghcr.io/jemartnz/swapp-frontend .
 ```
 
 En producción: Nginx sirve el frontend estático (puerto 80) y hace proxy de `/api/` al backend (Gunicorn, puerto 5000).
@@ -114,7 +122,8 @@ En producción: Nginx sirve el frontend estático (puerto 80) y hace proxy de `/
 | Recurso    | URL base          | Métodos                        |
 |------------|-------------------|--------------------------------|
 | Usuarios   | `/api/users`      | GET, POST, PUT, DELETE         |
-| Auth       | `/api/auth`       | POST `/login`, GET `/me`, POST `/refresh` |
+| Auth       | `/api/auth`       | POST `/login`, GET `/me`, POST `/refresh`, POST `/google/verify` |
+| Logout     | `/api/logout`     | POST                           |
 | Habilidades| `/api/skills`     | GET, POST, PUT, DELETE         |
 | Categorías | `/api/categories` | GET, POST, PUT, DELETE         |
 | Mensajes   | `/api/messages`   | GET, POST, PUT, DELETE         |

--- a/back/app.py
+++ b/back/app.py
@@ -11,7 +11,6 @@ from flask import send_from_directory
 from flask_migrate import Migrate
 from flask_cors import CORS
 from flask_jwt_extended import JWTManager
-from authlib.integrations.flask_client import OAuth
 from back.utils import APIException
 # from back.utils import generate_sitemap
 from back.admin import setup_admin
@@ -59,6 +58,7 @@ app.config["JWT_ACCESS_TOKEN_EXPIRES"] = timedelta(hours=6)
 app.config["JWT_REFRESH_TOKEN_EXPIRES"] = timedelta(days=30)
 app.config["SECRET_KEY"] = os.getenv("FLASK_APP_KEY")
 app.config["DEBUG"] = os.getenv("FLASK_DEBUG", "0") == "1"
+app.config["GOOGLE_CLIENT_ID"] = os.getenv("GOOGLE_CLIENT_ID")
 
 
 MIGRATIONS_DIR = os.path.join(BASE_DIR, "migrations")
@@ -67,7 +67,6 @@ db.init_app(app)
 CORS(app)
 setup_admin(app)
 jwt = JWTManager(app)
-oauth = OAuth()
 
 
 @app.errorhandler(APIException)

--- a/back/models.py
+++ b/back/models.py
@@ -29,6 +29,7 @@ class User(db.Model):
         default="away",
         nullable=False)
     accepts_terms = db.Column(db.Boolean, default=False, nullable=False)
+    google_id = db.Column(db.String(255), unique=True, nullable=True)
     created_at = db.Column(
         db.DateTime, default=lambda: datetime.now(timezone.utc))
 

--- a/back/requirements.txt
+++ b/back/requirements.txt
@@ -8,7 +8,7 @@ psycopg2
 python-dotenv
 wtforms
 flask-jwt-extended
-authlib
+google-auth
 requests
 gunicorn
 cloudinary

--- a/back/urls/user.py
+++ b/back/urls/user.py
@@ -2,12 +2,14 @@
     Users
 """
 from datetime import datetime
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, jsonify, request, current_app
 from sqlalchemy import func
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from flask_jwt_extended import create_access_token, create_refresh_token
 from flask_jwt_extended import jwt_required
 from flask_jwt_extended import get_jwt_identity
+from google.oauth2 import id_token as google_id_token
+from google.auth.transport import requests as google_requests
 from back.models import db, User, Skill, Category, Rating
 from back.utils import get_current_user, error_response, validate, success
 
@@ -338,3 +340,77 @@ def refresh():
     email = get_jwt_identity()
     new_token = create_access_token(identity=email)
     return success({"token": new_token})
+
+
+@users.route("/api/auth/google/verify", methods=["POST"])
+def google_verify():
+    """
+        Verifies a Google id_token, creates or retrieves the user,
+        and returns app JWT tokens
+    """
+    data = request.get_json() or {}
+    token = data.get("id_token")
+
+    if not token:
+        return jsonify({"error": "'id_token' is required"}), 400
+
+    client_id = current_app.config.get("GOOGLE_CLIENT_ID")
+    if not client_id:
+        return jsonify({"error": "Google OAuth not configured"}), 500
+
+    try:
+        id_info = google_id_token.verify_oauth2_token(
+            token, google_requests.Request(), client_id
+        )
+    except ValueError as e:
+        return jsonify({"error": "Invalid Google token"}), 401
+
+    google_id = id_info.get("sub")
+    email = id_info.get("email")
+    first_name = id_info.get("given_name", "")
+    last_name = id_info.get("family_name", "")
+    picture = id_info.get("picture")
+
+    if not email or not google_id:
+        return jsonify({"error": "Incomplete Google profile"}), 400
+
+    try:
+        user = User.query.filter_by(google_id=google_id).first()
+
+        if not user:
+            user = User.query.filter_by(email=email).first()
+            if user:
+                user.google_id = google_id
+            else:
+                user = User(
+                    first_name=first_name,
+                    last_name=last_name,
+                    email=email,
+                    profile_picture=picture,
+                    google_id=google_id,
+                    accepts_terms=True,
+                )
+                db.session.add(user)
+
+        db.session.commit()
+
+        access_token = create_access_token(identity=user.email)
+        refresh_token = create_refresh_token(identity=user.email)
+        return success({
+            "token": access_token,
+            "refresh_token": refresh_token,
+            "email": user.email,
+        })
+
+    except SQLAlchemyError as e:
+        db.session.rollback()
+        return error_response("Database error", e)
+
+
+@users.route("/api/logout", methods=["POST"])
+def logout():
+    """
+        Stateless logout — JWT is invalidated client-side.
+        This endpoint exists for frontend compatibility.
+    """
+    return success(message="Logged out")

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -31,6 +31,8 @@ services:
     build:
       context: .
       dockerfile: docker/prod/frontend.Dockerfile
+      args:
+        - VITE_GOOGLE_CLIENT_ID=${VITE_GOOGLE_CLIENT_ID}
     restart: always
     ports:
       - "80:80"

--- a/docker/prod/frontend.Dockerfile
+++ b/docker/prod/frontend.Dockerfile
@@ -6,6 +6,10 @@ COPY front/package.json front/package-lock.json* ./
 RUN npm install
 
 COPY front/ ./
+
+ARG VITE_GOOGLE_CLIENT_ID
+ENV VITE_GOOGLE_CLIENT_ID=$VITE_GOOGLE_CLIENT_ID
+
 RUN npm run build
 
 FROM nginx:alpine

--- a/front/.env.example
+++ b/front/.env.example
@@ -1,3 +1,4 @@
 # Vite environment variables (must start with VITE_)
 VITE_BACKEND_URL=http://localhost:5000
 VITE_APP_NAME=Swapp
+VITE_GOOGLE_CLIENT_ID=

--- a/front/assets/components/Navbar.jsx
+++ b/front/assets/components/Navbar.jsx
@@ -9,11 +9,7 @@ function Navbar() {
   const [user, setUser] = useState(null);
   const [categories, setCategories] = useState([]);
   const navigate = useNavigate();
-  const isLogged = !!(
-    user ||
-    localStorage.getItem("token") ||
-    localStorage.getItem("user")
-  );
+  const isLogged = !!(user || localStorage.getItem("token"));
   const [showLogoutModal, setShowLogoutModal] = useState(false);
 
   const FEATURED_CATEGORIES = [
@@ -46,20 +42,7 @@ function Navbar() {
         ? store.user
         : null;
 
-    const fromLocal = JSON.parse(localStorage.getItem("user") || "null");
-
-    if (fromStore) {
-      setUser(fromStore);
-    } else if (fromLocal) {
-      setUser({
-        first_name: fromLocal.first_name,
-        last_name: fromLocal.last_name,
-        email: fromLocal.email,
-        profile_picture: fromLocal.picture,
-      });
-    } else {
-      setUser(null);
-    }
+    setUser(fromStore || null);
 
     const fetchCategories = async () => {
       try {
@@ -79,27 +62,13 @@ function Navbar() {
     setShowLogoutModal(true);
   };
 
-  const confirmLogout = async () => {
-    try {
-      const googleUser = localStorage.getItem("user");
-
-      if (googleUser) {
-        await fetch(`${env.api}/api/logout`, { method: "POST" });
-        localStorage.removeItem("user");
-      }
-
-      localStorage.removeItem("token");
-      localStorage.removeItem("user");
-      dispatch({ type: "SET_USER", payload: {} });
-      dispatch({ type: "SET_TOKEN", payload: "" });
-      setUser(null);
-
-      navigate("/login");
-    } catch (error) {
-      console.error("Error al cerrar sesión:", error);
-      localStorage.clear();
-      navigate("/login");
-    }
+  const confirmLogout = () => {
+    localStorage.removeItem("token");
+    localStorage.removeItem("refresh_token");
+    dispatch({ type: "SET_USER", payload: {} });
+    dispatch({ type: "SET_TOKEN", payload: "" });
+    setUser(null);
+    navigate("/login");
   };
 
   return (

--- a/front/environ.js
+++ b/front/environ.js
@@ -1,4 +1,5 @@
 export const env = {
     api: import.meta.env.VITE_BACKEND_URL,
-    appName: import.meta.env.VITE_APP_NAME
+    appName: import.meta.env.VITE_APP_NAME,
+    googleClientId: import.meta.env.VITE_GOOGLE_CLIENT_ID,
 }

--- a/front/main.jsx
+++ b/front/main.jsx
@@ -1,13 +1,17 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
+import { GoogleOAuthProvider } from "@react-oauth/google";
+import { env } from "./environ";
 import "./index.css";
 import App from "./App.jsx";
 
 createRoot(document.querySelector("#root")).render(
   <StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
+    <GoogleOAuthProvider clientId={env.googleClientId}>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </GoogleOAuthProvider>
   </StrictMode>
 );

--- a/front/package.json
+++ b/front/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@react-oauth/google": "^0.12.2",
     "jwt-decode": "^4.0.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/front/pages/Login.jsx
+++ b/front/pages/Login.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import "../assets/styles/Login.css";
 import { Link, useNavigate } from "react-router";
+import { GoogleLogin } from "@react-oauth/google";
 import { env } from "../environ";
 import { useStore } from "../hooks/useStore";
 
@@ -10,6 +11,38 @@ const Login = () => {
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
   const navigate = useNavigate();
+
+  const saveTokensAndRedirect = (token, refreshToken) => {
+    localStorage.setItem("token", JSON.stringify(token));
+    if (refreshToken) localStorage.setItem("refresh_token", refreshToken);
+    dispatch({ type: "SET_TOKEN", payload: token });
+    navigate("/perfil");
+  };
+
+  const handleGoogleSuccess = async (credentialResponse) => {
+    try {
+      const response = await fetch(`${env.api}/api/auth/google/verify`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id_token: credentialResponse.credential }),
+      });
+
+      if (!response.ok) throw new Error("Error de autenticación con Google");
+
+      const data = await response.json();
+      const token = data?.data?.token;
+      const refreshToken = data?.data?.refresh_token;
+
+      if (token) {
+        saveTokensAndRedirect(token, refreshToken);
+      } else {
+        setError("No se pudo iniciar sesión con Google.");
+      }
+    } catch (err) {
+      console.error("Error Google login:", err);
+      setError("Error al iniciar sesión con Google");
+    }
+  };
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -42,10 +75,7 @@ const Login = () => {
       const refreshToken = data?.data?.refresh_token;
 
       if (token) {
-        localStorage.setItem("token", JSON.stringify(token));
-        if (refreshToken) localStorage.setItem("refresh_token", refreshToken);
-        dispatch({ type: "SET_TOKEN", payload: token });
-        navigate("/perfil");
+        saveTokensAndRedirect(token, refreshToken);
       } else {
         setError("Correo o contraseña incorrectos.");
       }
@@ -114,6 +144,20 @@ const Login = () => {
                 Iniciar sesión
               </button>
             </form>
+
+            <div className="text-center mt-3 mb-2">
+              <span className="text-muted" style={{ fontSize: "0.85rem" }}>— O continúa con —</span>
+            </div>
+
+            <div className="d-flex justify-content-center mb-3">
+              <GoogleLogin
+                onSuccess={handleGoogleSuccess}
+                onError={() => setError("Error al iniciar sesión con Google")}
+                locale="es"
+                text="signin_with"
+                shape="rectangular"
+              />
+            </div>
 
             <p className="mt-3 text-center">
               ¿No tienes cuenta?{" "}

--- a/front/pages/Register.jsx
+++ b/front/pages/Register.jsx
@@ -2,9 +2,12 @@ import "../assets/styles/Register.css";
 import React, { useState, useEffect } from "react";
 import { registerUser } from "../services/api";
 import { Link, useNavigate } from "react-router";
+import { GoogleLogin } from "@react-oauth/google";
 import { env } from "../environ";
+import { useStore } from "../hooks/useStore";
 
 function Register() {
+  const { dispatch } = useStore();
   const [formData, setFormData] = useState({
     first_name: "",
     last_name: "",
@@ -28,7 +31,36 @@ function Register() {
   const [showAlert, setShowAlert] = useState(false);
   const [errors, setErrors] = useState({});
   const [showModal, setShowModal] = useState(false);
+  const [googleError, setGoogleError] = useState("");
   const navigate = useNavigate();
+
+  const handleGoogleSuccess = async (credentialResponse) => {
+    try {
+      const response = await fetch(`${env.api}/api/auth/google/verify`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id_token: credentialResponse.credential }),
+      });
+
+      if (!response.ok) throw new Error("Error de autenticación con Google");
+
+      const data = await response.json();
+      const token = data?.data?.token;
+      const refreshToken = data?.data?.refresh_token;
+
+      if (token) {
+        localStorage.setItem("token", JSON.stringify(token));
+        if (refreshToken) localStorage.setItem("refresh_token", refreshToken);
+        dispatch({ type: "SET_TOKEN", payload: token });
+        navigate("/perfil");
+      } else {
+        setGoogleError("No se pudo registrar con Google.");
+      }
+    } catch (err) {
+      console.error("Error Google register:", err);
+      setGoogleError("Error al registrarse con Google");
+    }
+  };
 
   useEffect(() => {
     fetch(`${env.api}/api/categories`)
@@ -420,6 +452,24 @@ function Register() {
               <button type="submit" className="btn btn-main1 my-3">
                 Registrate
               </button>
+            </div>
+
+            <div className="text-center mb-2">
+              <span className="text-muted" style={{ fontSize: "0.85rem" }}>— O regístrate con —</span>
+            </div>
+
+            {googleError && (
+              <p className="text-danger text-center small">{googleError}</p>
+            )}
+
+            <div className="d-flex justify-content-center mb-3">
+              <GoogleLogin
+                onSuccess={handleGoogleSuccess}
+                onError={() => setGoogleError("Error al registrarse con Google")}
+                locale="es"
+                text="signup_with"
+                shape="rectangular"
+              />
             </div>
           </form>
           {showModal && (

--- a/front/pages/UserProfile.jsx
+++ b/front/pages/UserProfile.jsx
@@ -51,38 +51,9 @@ function UserProfile() {
   useEffect(() => {
     const rawToken = localStorage.getItem("token");
     const userToken = rawToken ? rawToken.replace(/^"|"$/g, "") : null;
-    const googleUser = localStorage.getItem("user");
 
-    if (!userToken && !googleUser) {
+    if (!userToken) {
       navigate("/login");
-      return;
-    }
-
-    // If coming from Google
-    if (googleUser) {
-      const data = JSON.parse(googleUser);
-      setUser({
-        id: data.id,
-        first_name: data.first_name,
-        last_name: data.last_name,
-        email: data.email,
-        profile_picture: data.profile_picture,
-        birth_date: null,
-        gender: "",
-        description: "",
-        skills: [],
-      });
-
-      setFormData({
-        first_name: data.first_name,
-        last_name: data.last_name,
-        email: data.email,
-        profile_picture: data.profile_picture,
-        birth_date: "",
-        gender: "",
-        description: "",
-      });
-
       return;
     }
 


### PR DESCRIPTION
## Summary

- Agrega `POST /api/auth/google/verify`: verifica el `id_token` de Google con `google-auth`, crea o recupera el usuario (vincula `google_id` a cuentas existentes por email), retorna JWT + refresh token con la misma forma que `/api/auth/login`
- Agrega `POST /api/logout`: endpoint stateless para compatibilidad con el frontend
- Agrega campo `google_id` en el modelo `User` (nullable, unique)
- Reemplaza `authlib` por `google-auth` en `requirements.txt`, elimina `OAuth()` de `app.py`
- Instala `@react-oauth/google`, envuelve la app con `GoogleOAuthProvider`
- Agrega botón Google en `Login.jsx` y `Register.jsx`
- Elimina el patrón legacy `localStorage.user` de `UserProfile.jsx` y `Navbar.jsx`
- Agrega `ARG/ENV VITE_GOOGLE_CLIENT_ID` en `docker/prod/frontend.Dockerfile` y `compose.prod.yml` para deployar en cualquier plataforma Docker

Closes #10

## Pendiente tras merge

```bash
docker compose exec backend flask db migrate -m "add google_id to users"
docker compose exec backend flask db upgrade
```

## Test plan

- [ ] Login con Google desde `/login` redirige a `/perfil` y guarda `token` + `refresh_token` en localStorage
- [ ] Registro con Google desde `/registro` crea usuario nuevo y redirige a `/perfil`
- [ ] Usuario con email ya registrado que hace login con Google → se vincula `google_id` sin crear duplicado
- [ ] `POST /api/auth/google/verify` con token inválido → 401
- [ ] `POST /api/auth/google/verify` sin `GOOGLE_CLIENT_ID` configurado → 500
- [ ] Logout limpia `token` y `refresh_token` de localStorage
- [ ] Build Docker prod con `VITE_GOOGLE_CLIENT_ID` como build ARG funciona correctamente