### PR TITLE
refactor: reduce code duplication in route handlers (#12)

### DIFF
--- a/back/cloudinary/routes.py
+++ b/back/cloudinary/routes.py
@@ -1,7 +1,7 @@
-from flask import Blueprint, request, jsonify
+from flask import Blueprint, request
 from flask_jwt_extended import jwt_required
 from back.models import db, User
-from back.utils import get_current_user, error_response, success
+from back.utils import get_current_user, error_response, success, forbidden, bad_request, not_found
 from back.cloudinary.config import cloudinary
 import cloudinary.uploader
 from werkzeug.utils import secure_filename
@@ -18,15 +18,15 @@ def upload_profile_picture(user_id):
     """
     current = get_current_user()
     if not current or current.id != user_id:
-        return jsonify({"error": "Forbidden"}), 403
+        return forbidden()
 
     try:
         user = User.query.get(user_id)
         if not user:
-            return jsonify({"error": "User not found"}), 404
+            return not_found("User")
 
         if "image" not in request.files:
-            return jsonify({"error": "No image was sent"}), 400
+            return bad_request("No image was sent")
 
         image = request.files["image"]
         safe_name = secure_filename(image.filename)
@@ -42,10 +42,10 @@ def upload_profile_picture(user_id):
         user.profile_picture = result.get("secure_url")
         db.session.commit()
 
-        return jsonify({
-            "message": "Profile picture updated",
-            "profile_picture": user.profile_picture
-        }), 200
+        return success(
+            {"profile_picture": user.profile_picture},
+            message="Profile picture updated"
+        )
 
     except Exception as e:
         db.session.rollback()

--- a/back/urls/category.py
+++ b/back/urls/category.py
@@ -2,10 +2,10 @@
     Categories
 """
 from sqlalchemy.exc import IntegrityError
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, request
 from flask_jwt_extended import jwt_required
 from back.models import db, Category
-from back.utils import error_response, validate, success
+from back.utils import error_response, validate, success, bad_request
 
 categories = Blueprint('categories', __name__)
 
@@ -45,7 +45,7 @@ def create_category():
 
     errors = validate(data, {"name": ["required"]})
     if errors:
-        return jsonify({"error": errors[0]}), 400
+        return bad_request(errors[0])
 
     name = data.get("name")
     new_category = Category(name=name)
@@ -54,7 +54,7 @@ def create_category():
         db.session.commit()
     except IntegrityError:
         db.session.rollback()
-        return jsonify({"error": "Category already exists"}), 400
+        return bad_request("Category already exists")
 
     return success(new_category.to_dict(), message="Category created successfully", status=201)
 

--- a/back/urls/exchange.py
+++ b/back/urls/exchange.py
@@ -1,10 +1,11 @@
 """
     Exchanges
 """
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, request
 from flask_jwt_extended import jwt_required
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
-from back.utils import get_current_user, error_response, validate, success
+from back.utils import (get_current_user, error_response, validate, success,
+                        forbidden, bad_request, not_found)
 from back.models import db, Exchange, User, Skill
 
 exchanges = Blueprint("exchanges", __name__)
@@ -34,7 +35,7 @@ def get_exchange(exchange_id):
         exchange = Exchange.query.get(exchange_id)
 
         if not exchange:
-            return jsonify({"error": "Exchange not found"}), 404
+            return not_found("Exchange")
 
         return success(exchange.to_dict())
 
@@ -87,14 +88,14 @@ def create_exchange():
 
     current = get_current_user()
     if not current or current.id != data.get("offerer_id"):
-        return jsonify({"error": "Forbidden"}), 403
+        return forbidden()
 
     errors = validate(data, {
         "offerer_id": ["required"],
         "skill_id":   ["required"],
     })
     if errors:
-        return jsonify({"error": errors[0]}), 400
+        return bad_request(errors[0])
 
     try:
 
@@ -114,7 +115,7 @@ def create_exchange():
 
     except IntegrityError:
         db.session.rollback()
-        return jsonify({"error": "Invalid or duplicate data"}), 400
+        return bad_request("Invalid or duplicate data")
 
     except SQLAlchemyError as e:
         db.session.rollback()
@@ -132,16 +133,15 @@ def complete_exchange(exchange_id):
         exchange = Exchange.query.get(exchange_id)
 
         if not exchange:
-            return jsonify({"error": "Exchange not found"}), 404
+            return not_found("Exchange")
 
         current = get_current_user()
         if not current or current.id not in (
                 exchange.offerer_id, exchange.demander_id):
-            return jsonify({"error": "Forbidden"}), 403
+            return forbidden()
 
         if exchange.is_completed:
-            return jsonify({
-                "error": "Exchange is already completed"}), 400
+            return bad_request("Exchange is already completed")
 
         exchange.is_completed = True
         exchange.completed_at = db.func.now()
@@ -184,31 +184,26 @@ def assign_demander(exchange_id):
 
     current = get_current_user()
     if not current or current.id != data.get("user_id"):
-        return jsonify({"error": "Forbidden"}), 403
+        return forbidden()
 
     try:
         demander_id = data.get("user_id")
         if not demander_id:
-            return jsonify({
-                "error": "Must provide user_id"}), 400
+            return bad_request("Must provide user_id")
 
         exchange = Exchange.query.get(exchange_id)
         if not exchange:
-            return jsonify({"error": "Exchange not found"}), 404
+            return not_found("Exchange")
 
         if exchange.demander_id is not None:
-            return jsonify({
-                "error": "Exchange already has a demander assigned"
-            }), 400
+            return bad_request("Exchange already has a demander assigned")
 
         if exchange.offerer_id == demander_id:
-            return jsonify({
-                "error": "The offerer cannot be their own demander"
-            }), 400
+            return bad_request("The offerer cannot be their own demander")
 
         demander = User.query.get(demander_id)
         if not demander:
-            return jsonify({"error": "Demander user not found"}), 404
+            return not_found("Demander user")
 
         exchange.demander_id = demander.id
         db.session.commit()
@@ -232,16 +227,14 @@ def delete_exchange(exchange_id):
         exchange = Exchange.query.get(exchange_id)
 
         if not exchange:
-            return jsonify({"error": "Exchange not found"}), 404
+            return not_found("Exchange")
 
         current = get_current_user()
         if not current or current.id != exchange.offerer_id:
-            return jsonify({"error": "Forbidden"}), 403
+            return forbidden()
 
         if exchange.is_completed:
-            return jsonify({
-                "error": "Cannot delete a completed exchange"
-            }), 400
+            return bad_request("Cannot delete a completed exchange")
 
         db.session.delete(exchange)
         db.session.commit()

--- a/back/urls/message.py
+++ b/back/urls/message.py
@@ -1,10 +1,11 @@
 """
     Messages
 """
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, request
 from flask_jwt_extended import jwt_required
 from back.models import db, Message
-from back.utils import get_current_user, error_response, validate, success
+from back.utils import (get_current_user, error_response, validate, success,
+                        forbidden, bad_request, not_found)
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 
 messages = Blueprint('messages', __name__)
@@ -71,7 +72,7 @@ def create_message():
     data = request.get_json() or {}
     current = get_current_user()
     if not current or current.id != data.get("sender_id"):
-        return jsonify({"error": "Forbidden"}), 403
+        return forbidden()
 
     errors = validate(data, {
         "content":     ["required"],
@@ -79,7 +80,7 @@ def create_message():
         "receiver_id": ["required"],
     })
     if errors:
-        return jsonify({"error": errors[0]}), 400
+        return bad_request(errors[0])
 
     try:
         msg = Message(
@@ -93,7 +94,7 @@ def create_message():
 
     except IntegrityError:
         db.session.rollback()
-        return jsonify({"error": "Invalid sender or receiver"}), 400
+        return bad_request("Invalid sender or receiver")
 
     except SQLAlchemyError as e:
         db.session.rollback()
@@ -113,10 +114,10 @@ def update_message(message_id):
 
         current = get_current_user()
         if not current or current.id != msg.sender_id:
-            return jsonify({"error": "Forbidden"}), 403
+            return forbidden()
 
         if not data:
-            return jsonify({"error": "Incomplete parameters"}), 400
+            return bad_request("Incomplete parameters")
 
         fields = [
             "content", "seen"
@@ -147,11 +148,11 @@ def delete_message(message_id):
         msg = Message.query.get(message_id)
 
         if not msg:
-            return jsonify({"error": "Message not found"}), 404
+            return not_found("Message")
 
         current = get_current_user()
         if not current or current.id != msg.sender_id:
-            return jsonify({"error": "Forbidden"}), 403
+            return forbidden()
 
         db.session.delete(msg)
         db.session.commit()

--- a/back/urls/rating.py
+++ b/back/urls/rating.py
@@ -1,10 +1,11 @@
 """
     Ratings
 """
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, request
 from flask_jwt_extended import jwt_required
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
-from back.utils import get_current_user, error_response, validate, success
+from back.utils import (get_current_user, error_response, validate, success,
+                        forbidden, bad_request, not_found)
 from back.models import db, User, Rating, Exchange
 
 ratings = Blueprint('ratings', __name__)
@@ -34,7 +35,7 @@ def get_rating(rating_id):
         rating = Rating.query.get(rating_id)
 
         if not rating:
-            return jsonify({"error": "Rating not found"}), 404
+            return not_found("Rating")
 
         return success(rating.to_dict())
 
@@ -52,7 +53,7 @@ def create_rating():
     data = request.get_json() or {}
     current = get_current_user()
     if not current or current.id != data.get("rater_id"):
-        return jsonify({"error": "Forbidden"}), 403
+        return forbidden()
 
     errors = validate(data, {
         "exchange_id": ["required"],
@@ -60,7 +61,7 @@ def create_rating():
         "score":       ["required", ("min", 1), ("max", 5)],
     })
     if errors:
-        return jsonify({"error": errors[0]}), 400
+        return bad_request(errors[0])
 
     try:
 
@@ -73,9 +74,7 @@ def create_rating():
             rated_id = exchange.offerer_id
 
         if not rated_id:
-            return jsonify({
-                "error":
-                "The exchange does not have a demander assigned yet"}), 400
+            return bad_request("The exchange does not have a demander assigned yet")
 
         rated = User.query.get_or_404(rated_id)
 
@@ -95,7 +94,7 @@ def create_rating():
 
     except IntegrityError:
         db.session.rollback()
-        return jsonify({"error": "Invalid parameters"}), 400
+        return bad_request("Invalid parameters")
 
     except SQLAlchemyError as e:
         db.session.rollback()
@@ -114,17 +113,17 @@ def update_rating(rating_id):
         rating = Rating.query.get(rating_id)
 
         if not rating:
-            return jsonify({"error": "Rating not found"}), 404
+            return not_found("Rating")
 
         current = get_current_user()
         if not current or current.id != rating.rater_id:
-            return jsonify({"error": "Forbidden"}), 403
+            return forbidden()
 
         errors = validate(data, {
             "score": [("min", 1), ("max", 5)],
         })
         if errors:
-            return jsonify({"error": errors[0]}), 400
+            return bad_request(errors[0])
 
         fields = [
             "score", "comment"
@@ -153,11 +152,11 @@ def delete_rating(rating_id):
         rating = Rating.query.get(rating_id)
 
         if not rating:
-            return jsonify({"error": "Rating not found"}), 404
+            return not_found("Rating")
 
         current = get_current_user()
         if not current or current.id != rating.rater_id:
-            return jsonify({"error": "Forbidden"}), 403
+            return forbidden()
 
         db.session.delete(rating)
         db.session.commit()

--- a/back/urls/skill.py
+++ b/back/urls/skill.py
@@ -2,10 +2,10 @@
     Skills
 """
 from sqlalchemy.exc import IntegrityError
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, request
 from flask_jwt_extended import jwt_required
 from back.models import db, Skill
-from back.utils import error_response, validate, success
+from back.utils import error_response, validate, success, bad_request
 
 skills = Blueprint('skills', __name__)
 
@@ -50,7 +50,7 @@ def create_skill():
         "category_id": ["required"],
     })
     if errors:
-        return jsonify({"error": errors[0]}), 400
+        return bad_request(errors[0])
 
     new_skill = Skill(
         name=data["name"],
@@ -63,7 +63,7 @@ def create_skill():
         db.session.commit()
     except IntegrityError:
         db.session.rollback()
-        return jsonify({"error": "Skill already exists"}), 400
+        return bad_request("Skill already exists")
     return success({"id": new_skill.id}, message="Skill created successfully", status=201)
 
 

--- a/back/urls/user.py
+++ b/back/urls/user.py
@@ -11,7 +11,8 @@ from flask_jwt_extended import get_jwt_identity
 from google.oauth2 import id_token as google_id_token
 from google.auth.transport import requests as google_requests
 from back.models import db, User, Skill, Category, Rating
-from back.utils import get_current_user, error_response, validate, success
+from back.utils import (get_current_user, error_response, validate, success,
+                        forbidden, bad_request, not_found)
 
 users = Blueprint('users', __name__)
 
@@ -52,7 +53,7 @@ def get_user(user_id):
         user = User.query.get(user_id)
 
         if not user:
-            return jsonify({"error": "User not found"}), 404
+            return not_found("User")
 
         usr = user.to_dict()
         usr["skills"] = [s.to_dict() for s in user.skills]
@@ -107,11 +108,11 @@ def delete_user(user_id):
     """
     current = get_current_user()
     if not current or current.id != user_id:
-        return jsonify({"error": "Forbidden"}), 403
+        return forbidden()
 
     user = User.query.get(user_id)
     if not user:
-        return jsonify({"error": "User not found"}), 404
+        return not_found("User")
 
     try:
         db.session.delete(user)
@@ -139,7 +140,7 @@ def create_user():
         "birth_date": ["date"],
     })
     if errors:
-        return jsonify({"error": errors[0]}), 400
+        return bad_request(errors[0])
 
     try:
         usr = User(
@@ -172,7 +173,7 @@ def create_user():
 
     except IntegrityError:
         db.session.rollback()
-        return jsonify({"error": "Email is already registered"}), 400
+        return bad_request("Email is already registered")
 
     except SQLAlchemyError as e:
         db.session.rollback()
@@ -187,7 +188,7 @@ def update_user(user_id):
     """
     current = get_current_user()
     if not current or current.id != user_id:
-        return jsonify({"error": "Forbidden"}), 403
+        return forbidden()
 
     data = request.get_json() or {}
 
@@ -197,7 +198,7 @@ def update_user(user_id):
         "birth_date": ["date"],
     })
     if errors:
-        return jsonify({"error": errors[0]}), 400
+        return bad_request(errors[0])
 
     try:
         user = User.query.get_or_404(user_id)
@@ -221,7 +222,7 @@ def update_user(user_id):
 
     except IntegrityError:
         db.session.rollback()
-        return jsonify({"error": "Email is already registered"}), 400
+        return bad_request("Email is already registered")
 
     except SQLAlchemyError as e:
         db.session.rollback()
@@ -236,7 +237,7 @@ def update_user_skill(user_id):
     """
     current = get_current_user()
     if not current or current.id != user_id:
-        return jsonify({"error": "Forbidden"}), 403
+        return forbidden()
 
     data = request.get_json() or {}
     try:
@@ -245,9 +246,7 @@ def update_user_skill(user_id):
         skill = Skill.query.get(skill_id)
 
         if not usr or not skill:
-            return jsonify({
-                "error": "User or Skill not found"
-            }), 404
+            return not_found("User or Skill")
 
         if (not data) or ("associate" in data and "disassociate" in data):
             return jsonify({
@@ -267,7 +266,7 @@ def update_user_skill(user_id):
 
     except IntegrityError:
         db.session.rollback()
-        return jsonify({"error": "Email is already registered"}), 400
+        return bad_request("Email is already registered")
 
     except SQLAlchemyError as e:
         db.session.rollback()
@@ -288,7 +287,7 @@ def login():
         "password": ["required"],
     })
     if errors:
-        return jsonify({"error": errors[0]}), 400
+        return bad_request(errors[0])
 
     email = data.get("email")
     passw = data.get("password")
@@ -314,19 +313,19 @@ def login():
 
 @users.route("/api/auth/me", methods=["GET"])
 @jwt_required()
-def get_current_user():
+def get_me():
     """
         Returns the user associated with the authorization token
     """
     email = get_jwt_identity()
 
     if not email:
-        return jsonify({"error": "Token without email"}), 400
+        return bad_request("Token without email")
 
     user = User.query.filter_by(email=email).first()
 
     if not user:
-        return jsonify({"error": "User not found"}), 404
+        return not_found("User")
 
     return success(user.to_dict())
 
@@ -352,7 +351,7 @@ def google_verify():
     token = data.get("id_token")
 
     if not token:
-        return jsonify({"error": "'id_token' is required"}), 400
+        return bad_request("'id_token' is required")
 
     client_id = current_app.config.get("GOOGLE_CLIENT_ID")
     if not client_id:
@@ -372,7 +371,7 @@ def google_verify():
     picture = id_info.get("picture")
 
     if not email or not google_id:
-        return jsonify({"error": "Incomplete Google profile"}), 400
+        return bad_request("Incomplete Google profile")
 
     try:
         user = User.query.filter_by(google_id=google_id).first()

--- a/back/utils.py
+++ b/back/utils.py
@@ -97,6 +97,16 @@ def not_found(resource="Resource"):
     return jsonify({"error": f"{resource} not found"}), 404
 
 
+def forbidden():
+    """Return a standardised 403 Forbidden response."""
+    return jsonify({"error": "Forbidden"}), 403
+
+
+def bad_request(message):
+    """Return a standardised 400 Bad Request response."""
+    return jsonify({"error": message}), 400
+
+
 def error_response(message, e, status=500):
     """Return a JSON error response. Includes exception detail only in DEBUG."""
     body = {"error": message}


### PR DESCRIPTION
## Summary

- Added `forbidden()` and `bad_request()` helpers to `back/utils.py`
- Replaced 13× inline `jsonify({"error": "Forbidden"}), 403` with `forbidden()` across all blueprints
- Replaced inline `jsonify({"error": ...}), 400/404` patterns with `bad_request()` / `not_found()`
- Removed `jsonify` import from blueprints that no longer need it directly
- Renamed `/api/auth/me` handler from `get_current_user` → `get_me` (was shadowing the utility import, causing a latent bug)
- Standardized `cloudinary/routes.py` to use `success()` instead of bare `jsonify()`

Closes #12

## Test plan

- [ ] `POST /api/auth/login` returns 400 on missing fields
- [ ] `DELETE /api/users/<id>` returns 403 when not the owner
- [ ] `PUT /api/messages/<id>` returns 403 when not the sender
- [ ] `GET /api/auth/me` still works (URL unchanged, handler renamed to `get_me`)
- [ ] `POST /api/users/<id>/profile-picture` returns standardised JSON on forbidden/not-found