### PR TITLE
feat: add backend test suite with pytest (#13)

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,6 +7,9 @@ verify_ssl = true
 flake8 = "*"
 black = "*"
 eralchemy = {extras = ["graphviz"], version = "*"}
+pytest = "*"
+pytest-flask = "*"
+pytest-cov = "*"
 
 [packages]
 flask = "*"
@@ -32,3 +35,5 @@ init="flask db init"
 migrate="flask db migrate"
 upgrade="flask db upgrade"
 diagram = "python scripts/generate_diagram.py"
+test = "pytest"
+test-cov = "pytest --cov=back --cov-report=term-missing"

--- a/back/requirements.txt
+++ b/back/requirements.txt
@@ -2,13 +2,15 @@ flask
 sqlalchemy
 flask-cors
 flask-sqlalchemy
-flask-admin
+flask-swagger
 flask-migrate
 psycopg2
 python-dotenv
-wtforms
 flask-jwt-extended
 google-auth
 requests
 gunicorn
 cloudinary
+pytest
+pytest-flask
+pytest-cov

--- a/back/tests/conftest.py
+++ b/back/tests/conftest.py
@@ -1,0 +1,177 @@
+"""
+Shared fixtures for all test modules.
+"""
+import pytest
+from sqlalchemy.pool import StaticPool
+from flask_jwt_extended import create_access_token
+
+from back.app import app as flask_app
+from back.models import db, User, Category, Skill, Exchange, Message, Rating
+
+
+# ── App & client ──────────────────────────────────────────────────────────────
+
+@pytest.fixture(scope="function")
+def app():
+    """
+    Flask app configured for testing.
+    Uses SQLite in-memory with StaticPool so all connections share
+    the same in-memory database within a single test.
+    """
+    flask_app.config.update({
+        "TESTING": True,
+        "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:",
+        "SQLALCHEMY_ENGINE_OPTIONS": {
+            "connect_args": {"check_same_thread": False},
+            "poolclass": StaticPool,
+        },
+        "JWT_SECRET_KEY": "test-secret",
+        "DEBUG": False,
+        "GOOGLE_CLIENT_ID": "test-client-id",
+    })
+
+    ctx = flask_app.app_context()
+    ctx.push()
+    db.create_all()
+
+    yield flask_app
+
+    db.session.remove()
+    db.drop_all()
+    ctx.pop()
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+# ── Factories ─────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def make_user():
+    """Returns a factory that creates and commits a User row."""
+    counter = {"n": 0}
+
+    def _make(email=None, password="password123",
+              first_name="Test", last_name="User", accepts_terms=True):
+        counter["n"] += 1
+        if email is None:
+            email = f"user{counter['n']}@test.com"
+        user = User(
+            first_name=first_name,
+            last_name=last_name,
+            email=email,
+            accepts_terms=accepts_terms,
+        )
+        user.password = password
+        db.session.add(user)
+        db.session.commit()
+        return user
+
+    return _make
+
+
+@pytest.fixture
+def make_category():
+    """Returns a factory that creates and commits a Category row."""
+    counter = {"n": 0}
+
+    def _make(name=None):
+        counter["n"] += 1
+        if name is None:
+            name = f"Categoria {counter['n']}"
+        cat = Category(name=name)
+        db.session.add(cat)
+        db.session.commit()
+        return cat
+
+    return _make
+
+
+@pytest.fixture
+def make_skill():
+    """Returns a factory that creates and commits a Skill row."""
+    counter = {"n": 0}
+
+    def _make(name=None, category_id=None, description=""):
+        counter["n"] += 1
+        if name is None:
+            name = f"Skill {counter['n']}"
+        if category_id is None:
+            cat = Category(name=f"Cat-auto-{counter['n']}")
+            db.session.add(cat)
+            db.session.flush()
+            category_id = cat.id
+        skill = Skill(name=name, description=description, category_id=category_id)
+        db.session.add(skill)
+        db.session.commit()
+        return skill
+
+    return _make
+
+
+@pytest.fixture
+def make_exchange():
+    """Returns a factory that creates and commits an Exchange row."""
+    def _make(offerer_id, skill_id, demander_id=None, is_completed=False):
+        exchange = Exchange(
+            offerer_id=offerer_id,
+            skill_id=skill_id,
+            demander_id=demander_id,
+            is_completed=is_completed,
+        )
+        db.session.add(exchange)
+        db.session.commit()
+        return exchange
+
+    return _make
+
+
+@pytest.fixture
+def make_message():
+    """Returns a factory that creates and commits a Message row."""
+    def _make(sender_id, receiver_id, content="Hola!"):
+        msg = Message(
+            sender_id=sender_id,
+            receiver_id=receiver_id,
+            content=content,
+        )
+        db.session.add(msg)
+        db.session.commit()
+        return msg
+
+    return _make
+
+
+@pytest.fixture
+def make_rating():
+    """Returns a factory that creates and commits a Rating row."""
+    def _make(exchange_id, rater_id, rated_id, score=5, comment=None):
+        rating = Rating(
+            exchange_id=exchange_id,
+            rater_id=rater_id,
+            rated_id=rated_id,
+            score=score,
+            comment=comment,
+        )
+        db.session.add(rating)
+        db.session.commit()
+        return rating
+
+    return _make
+
+
+# ── Auth helpers ──────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def auth_headers():
+    """
+    Returns a helper that generates JWT Authorization headers for a given user.
+    Requires an active app context (provided by the `app` fixture).
+    """
+    def _make(user):
+        token = create_access_token(identity=user.email)
+        return {"Authorization": f"Bearer {token}"}
+
+    return _make

--- a/back/tests/test_auth.py
+++ b/back/tests/test_auth.py
@@ -1,0 +1,166 @@
+"""
+Tests for authentication endpoints:
+  POST /api/auth/login
+  GET  /api/auth/me
+  POST /api/auth/refresh
+  POST /api/auth/google/verify
+  POST /api/logout
+"""
+from unittest.mock import patch
+
+from flask_jwt_extended import create_refresh_token
+
+
+# ── Login ─────────────────────────────────────────────────────────────────────
+
+def test_login_success(client, make_user):
+    user = make_user(email="alice@test.com", password="secret123")
+    res = client.post("/api/auth/login",
+                      json={"email": "alice@test.com", "password": "secret123"})
+    assert res.status_code == 200
+    data = res.get_json()["data"]
+    assert "token" in data
+    assert "refresh_token" in data
+    assert data["email"] == user.email
+
+
+def test_login_wrong_password(client, make_user):
+    make_user(email="alice@test.com", password="secret123")
+    res = client.post("/api/auth/login",
+                      json={"email": "alice@test.com", "password": "wrong"})
+    assert res.status_code == 401
+
+
+def test_login_unknown_email(client):
+    res = client.post("/api/auth/login",
+                      json={"email": "noone@test.com", "password": "secret123"})
+    assert res.status_code == 401
+
+
+def test_login_missing_email(client):
+    res = client.post("/api/auth/login", json={"password": "secret123"})
+    assert res.status_code == 400
+
+
+def test_login_missing_password(client):
+    res = client.post("/api/auth/login", json={"email": "alice@test.com"})
+    assert res.status_code == 400
+
+
+# ── /api/auth/me ──────────────────────────────────────────────────────────────
+
+def test_get_me_success(client, make_user, auth_headers):
+    user = make_user(email="alice@test.com")
+    res = client.get("/api/auth/me", headers=auth_headers(user))
+    assert res.status_code == 200
+    assert res.get_json()["data"]["email"] == user.email
+
+
+def test_get_me_no_token(client):
+    res = client.get("/api/auth/me")
+    assert res.status_code == 401
+
+
+def test_get_me_invalid_token(client):
+    res = client.get("/api/auth/me",
+                     headers={"Authorization": "Bearer not.a.real.token"})
+    assert res.status_code == 422
+
+
+# ── Refresh token ─────────────────────────────────────────────────────────────
+
+def test_refresh_success(client, make_user):
+    user = make_user(email="alice@test.com")
+    refresh_token = create_refresh_token(identity=user.email)
+    res = client.post("/api/auth/refresh",
+                      headers={"Authorization": f"Bearer {refresh_token}"})
+    assert res.status_code == 200
+    assert "token" in res.get_json()["data"]
+
+
+def test_refresh_with_access_token_rejected(client, make_user, auth_headers):
+    user = make_user()
+    res = client.post("/api/auth/refresh", headers=auth_headers(user))
+    assert res.status_code == 422
+
+
+def test_refresh_no_token(client):
+    res = client.post("/api/auth/refresh")
+    assert res.status_code == 401
+
+
+# ── Google OAuth ──────────────────────────────────────────────────────────────
+
+GOOGLE_PAYLOAD = {
+    "sub": "google-id-123",
+    "email": "google@test.com",
+    "given_name": "Google",
+    "family_name": "User",
+    "picture": "https://example.com/photo.jpg",
+}
+
+
+def test_google_verify_missing_token(client):
+    res = client.post("/api/auth/google/verify", json={})
+    assert res.status_code == 400
+
+
+def test_google_verify_invalid_token(client):
+    with patch("back.urls.user.google_id_token.verify_oauth2_token",
+               side_effect=ValueError("bad token")):
+        res = client.post("/api/auth/google/verify",
+                          json={"id_token": "bad-token"})
+    assert res.status_code == 401
+
+
+def test_google_verify_new_user(client):
+    """A new Google user is created and JWT tokens are returned."""
+    with patch("back.urls.user.google_id_token.verify_oauth2_token",
+               return_value=GOOGLE_PAYLOAD):
+        res = client.post("/api/auth/google/verify",
+                          json={"id_token": "valid-token"})
+    assert res.status_code == 200
+    data = res.get_json()["data"]
+    assert "token" in data
+    assert "refresh_token" in data
+    assert data["email"] == "google@test.com"
+
+
+def test_google_verify_existing_email_links_google_id(client, make_user):
+    """Existing user by email gets google_id linked."""
+    user = make_user(email="google@test.com")
+    assert user.google_id is None
+
+    with patch("back.urls.user.google_id_token.verify_oauth2_token",
+               return_value=GOOGLE_PAYLOAD):
+        res = client.post("/api/auth/google/verify",
+                          json={"id_token": "valid-token"})
+    assert res.status_code == 200
+
+    from back.models import db, User
+    db.session.refresh(user)
+    assert user.google_id == "google-id-123"
+
+
+def test_google_verify_returning_user(client, make_user):
+    """Returning Google user (google_id already set) gets tokens without duplicates."""
+    user = make_user(email="google@test.com")
+    from back.models import db
+    user.google_id = "google-id-123"
+    db.session.commit()
+
+    with patch("back.urls.user.google_id_token.verify_oauth2_token",
+               return_value=GOOGLE_PAYLOAD):
+        res = client.post("/api/auth/google/verify",
+                          json={"id_token": "valid-token"})
+    assert res.status_code == 200
+
+    from back.models import User
+    assert User.query.filter_by(email="google@test.com").count() == 1
+
+
+# ── Logout ────────────────────────────────────────────────────────────────────
+
+def test_logout(client):
+    res = client.post("/api/logout")
+    assert res.status_code == 200

--- a/back/tests/test_categories.py
+++ b/back/tests/test_categories.py
@@ -1,0 +1,106 @@
+"""
+Tests for category endpoints:
+  GET    /api/categories
+  GET    /api/categories/<id>
+  POST   /api/categories
+  PUT    /api/categories/<id>
+  DELETE /api/categories/<id>
+"""
+
+
+# ── GET endpoints ─────────────────────────────────────────────────────────────
+
+def test_get_categories_empty(client):
+    res = client.get("/api/categories")
+    assert res.status_code == 200
+    assert res.get_json()["data"] == []
+
+
+def test_get_categories_includes_skills(client, make_category, make_skill):
+    cat = make_category(name="Tecnología")
+    make_skill(name="Python", category_id=cat.id)
+    make_skill(name="Go", category_id=cat.id)
+
+    res = client.get("/api/categories")
+    assert res.status_code == 200
+    data = res.get_json()["data"]
+    assert len(data) == 1
+    assert len(data[0]["skills"]) == 2
+
+
+def test_get_category_found(client, make_category):
+    cat = make_category(name="Arte")
+    res = client.get(f"/api/categories/{cat.id}")
+    assert res.status_code == 200
+    assert res.get_json()["data"]["name"] == "Arte"
+
+
+def test_get_category_not_found(client):
+    res = client.get("/api/categories/9999")
+    assert res.status_code == 404
+
+
+# ── POST /api/categories ──────────────────────────────────────────────────────
+
+def test_create_category_success(client, make_user, auth_headers):
+    user = make_user()
+    res = client.post("/api/categories",
+                      json={"name": "Tecnología"},
+                      headers=auth_headers(user))
+    assert res.status_code == 201
+    assert res.get_json()["data"]["name"] == "Tecnología"
+
+
+def test_create_category_duplicate_name(client, make_user, make_category,
+                                        auth_headers):
+    user = make_user()
+    make_category(name="Tecnología")
+    res = client.post("/api/categories",
+                      json={"name": "Tecnología"},
+                      headers=auth_headers(user))
+    assert res.status_code == 400
+
+
+def test_create_category_missing_name(client, make_user, auth_headers):
+    user = make_user()
+    res = client.post("/api/categories", json={}, headers=auth_headers(user))
+    assert res.status_code == 400
+
+
+def test_create_category_no_token(client):
+    res = client.post("/api/categories", json={"name": "Tecnología"})
+    assert res.status_code == 401
+
+
+# ── PUT /api/categories/<id> ──────────────────────────────────────────────────
+
+def test_update_category_success(client, make_user, make_category, auth_headers):
+    user = make_user()
+    cat = make_category(name="Arte")
+    res = client.put(f"/api/categories/{cat.id}",
+                     json={"name": "Arte Digital"},
+                     headers=auth_headers(user))
+    assert res.status_code == 200
+    assert res.get_json()["data"]["name"] == "Arte Digital"
+
+
+def test_update_category_no_token(client, make_category):
+    cat = make_category()
+    res = client.put(f"/api/categories/{cat.id}", json={"name": "Nuevo"})
+    assert res.status_code == 401
+
+
+# ── DELETE /api/categories/<id> ───────────────────────────────────────────────
+
+def test_delete_category_success(client, make_user, make_category, auth_headers):
+    user = make_user()
+    cat = make_category()
+    res = client.delete(f"/api/categories/{cat.id}", headers=auth_headers(user))
+    assert res.status_code == 200
+    assert client.get(f"/api/categories/{cat.id}").status_code == 404
+
+
+def test_delete_category_no_token(client, make_category):
+    cat = make_category()
+    res = client.delete(f"/api/categories/{cat.id}")
+    assert res.status_code == 401

--- a/back/tests/test_exchanges.py
+++ b/back/tests/test_exchanges.py
@@ -1,0 +1,279 @@
+"""
+Tests for exchange endpoints — full lifecycle:
+  GET    /api/exchanges
+  GET    /api/exchanges/<id>
+  GET    /api/exchanges/offerer/<user_id>
+  GET    /api/exchanges/demander/<user_id>
+  GET    /api/exchanges/user/<user_id>
+  POST   /api/exchanges
+  PUT    /api/exchanges/<id>/complete
+  PUT    /api/exchanges/join/<id>
+  DELETE /api/exchanges/<id>
+"""
+
+
+# ── GET endpoints ─────────────────────────────────────────────────────────────
+
+def test_get_exchanges_empty(client):
+    res = client.get("/api/exchanges")
+    assert res.status_code == 200
+    assert res.get_json()["data"] == []
+
+
+def test_get_exchanges_list(client, make_user, make_skill, make_exchange):
+    offerer = make_user()
+    skill = make_skill()
+    make_exchange(offerer_id=offerer.id, skill_id=skill.id)
+
+    res = client.get("/api/exchanges")
+    assert res.status_code == 200
+    assert len(res.get_json()["data"]) == 1
+
+
+def test_get_exchange_found(client, make_user, make_skill, make_exchange):
+    offerer = make_user()
+    skill = make_skill()
+    exchange = make_exchange(offerer_id=offerer.id, skill_id=skill.id)
+
+    res = client.get(f"/api/exchanges/{exchange.id}")
+    assert res.status_code == 200
+    assert res.get_json()["data"]["offerer_id"] == offerer.id
+
+
+def test_get_exchange_not_found(client):
+    res = client.get("/api/exchanges/9999")
+    assert res.status_code == 404
+
+
+def test_get_exchanges_by_offerer(client, make_user, make_skill, make_exchange):
+    offerer = make_user()
+    other = make_user(email="other@test.com")
+    skill = make_skill()
+    make_exchange(offerer_id=offerer.id, skill_id=skill.id)
+    make_exchange(offerer_id=other.id, skill_id=skill.id)
+
+    res = client.get(f"/api/exchanges/offerer/{offerer.id}")
+    assert res.status_code == 200
+    assert len(res.get_json()["data"]) == 1
+
+
+def test_get_exchanges_by_user(client, make_user, make_skill, make_exchange):
+    offerer = make_user(email="offerer@test.com")
+    demander = make_user(email="demander@test.com")
+    unrelated = make_user(email="unrelated@test.com")
+    skill = make_skill()
+    make_exchange(offerer_id=offerer.id, skill_id=skill.id,
+                  demander_id=demander.id)
+    make_exchange(offerer_id=unrelated.id, skill_id=skill.id)
+
+    res = client.get(f"/api/exchanges/user/{offerer.id}")
+    assert res.status_code == 200
+    assert len(res.get_json()["data"]) == 1
+
+
+# ── POST /api/exchanges ───────────────────────────────────────────────────────
+
+def test_create_exchange_success(client, make_user, make_skill, auth_headers):
+    offerer = make_user()
+    skill = make_skill()
+    res = client.post("/api/exchanges",
+                      json={"offerer_id": offerer.id, "skill_id": skill.id},
+                      headers=auth_headers(offerer))
+    assert res.status_code == 201
+    assert "id" in res.get_json()["data"]
+
+
+def test_create_exchange_forbidden(client, make_user, make_skill, auth_headers):
+    offerer = make_user(email="offerer@test.com")
+    other = make_user(email="other@test.com")
+    skill = make_skill()
+    res = client.post("/api/exchanges",
+                      json={"offerer_id": offerer.id, "skill_id": skill.id},
+                      headers=auth_headers(other))
+    assert res.status_code == 403
+
+
+def test_create_exchange_missing_skill_id(client, make_user, auth_headers):
+    offerer = make_user()
+    res = client.post("/api/exchanges",
+                      json={"offerer_id": offerer.id},
+                      headers=auth_headers(offerer))
+    assert res.status_code == 400
+
+
+def test_create_exchange_no_token(client, make_user, make_skill):
+    offerer = make_user()
+    skill = make_skill()
+    res = client.post("/api/exchanges",
+                      json={"offerer_id": offerer.id, "skill_id": skill.id})
+    assert res.status_code == 401
+
+
+# ── PUT /api/exchanges/join/<id> ──────────────────────────────────────────────
+
+def test_join_exchange_success(client, make_user, make_skill, make_exchange,
+                               auth_headers):
+    offerer = make_user(email="offerer@test.com")
+    demander = make_user(email="demander@test.com")
+    skill = make_skill()
+    exchange = make_exchange(offerer_id=offerer.id, skill_id=skill.id)
+
+    res = client.put(f"/api/exchanges/join/{exchange.id}",
+                     json={"user_id": demander.id},
+                     headers=auth_headers(demander))
+    assert res.status_code == 200
+    assert res.get_json()["data"]["demander_id"] == demander.id
+
+
+def test_join_exchange_self_assignment_rejected(client, make_user, make_skill,
+                                                make_exchange, auth_headers):
+    offerer = make_user()
+    skill = make_skill()
+    exchange = make_exchange(offerer_id=offerer.id, skill_id=skill.id)
+
+    res = client.put(f"/api/exchanges/join/{exchange.id}",
+                     json={"user_id": offerer.id},
+                     headers=auth_headers(offerer))
+    assert res.status_code == 400
+
+
+def test_join_exchange_already_has_demander(client, make_user, make_skill,
+                                            make_exchange, auth_headers):
+    offerer = make_user(email="offerer@test.com")
+    demander = make_user(email="demander@test.com")
+    third = make_user(email="third@test.com")
+    skill = make_skill()
+    exchange = make_exchange(offerer_id=offerer.id, skill_id=skill.id,
+                             demander_id=demander.id)
+
+    res = client.put(f"/api/exchanges/join/{exchange.id}",
+                     json={"user_id": third.id},
+                     headers=auth_headers(third))
+    assert res.status_code == 400
+
+
+def test_join_exchange_not_found(client, make_user, auth_headers):
+    user = make_user()
+    res = client.put("/api/exchanges/join/9999",
+                     json={"user_id": user.id},
+                     headers=auth_headers(user))
+    assert res.status_code == 404
+
+
+def test_join_exchange_forbidden(client, make_user, make_skill, make_exchange,
+                                 auth_headers):
+    offerer = make_user(email="offerer@test.com")
+    demander = make_user(email="demander@test.com")
+    other = make_user(email="other@test.com")
+    skill = make_skill()
+    exchange = make_exchange(offerer_id=offerer.id, skill_id=skill.id)
+
+    res = client.put(f"/api/exchanges/join/{exchange.id}",
+                     json={"user_id": demander.id},
+                     headers=auth_headers(other))
+    assert res.status_code == 403
+
+
+# ── PUT /api/exchanges/<id>/complete ─────────────────────────────────────────
+
+def test_complete_exchange_by_offerer(client, make_user, make_skill,
+                                      make_exchange, auth_headers):
+    offerer = make_user(email="offerer@test.com")
+    demander = make_user(email="demander@test.com")
+    skill = make_skill()
+    exchange = make_exchange(offerer_id=offerer.id, skill_id=skill.id,
+                             demander_id=demander.id)
+
+    res = client.put(f"/api/exchanges/{exchange.id}/complete",
+                     headers=auth_headers(offerer))
+    assert res.status_code == 200
+
+
+def test_complete_exchange_by_demander(client, make_user, make_skill,
+                                       make_exchange, auth_headers):
+    offerer = make_user(email="offerer@test.com")
+    demander = make_user(email="demander@test.com")
+    skill = make_skill()
+    exchange = make_exchange(offerer_id=offerer.id, skill_id=skill.id,
+                             demander_id=demander.id)
+
+    res = client.put(f"/api/exchanges/{exchange.id}/complete",
+                     headers=auth_headers(demander))
+    assert res.status_code == 200
+
+
+def test_complete_exchange_forbidden(client, make_user, make_skill,
+                                     make_exchange, auth_headers):
+    offerer = make_user(email="offerer@test.com")
+    demander = make_user(email="demander@test.com")
+    outsider = make_user(email="outsider@test.com")
+    skill = make_skill()
+    exchange = make_exchange(offerer_id=offerer.id, skill_id=skill.id,
+                             demander_id=demander.id)
+
+    res = client.put(f"/api/exchanges/{exchange.id}/complete",
+                     headers=auth_headers(outsider))
+    assert res.status_code == 403
+
+
+def test_complete_exchange_already_completed(client, make_user, make_skill,
+                                             make_exchange, auth_headers):
+    offerer = make_user(email="offerer@test.com")
+    demander = make_user(email="demander@test.com")
+    skill = make_skill()
+    exchange = make_exchange(offerer_id=offerer.id, skill_id=skill.id,
+                             demander_id=demander.id, is_completed=True)
+
+    res = client.put(f"/api/exchanges/{exchange.id}/complete",
+                     headers=auth_headers(offerer))
+    assert res.status_code == 400
+
+
+def test_complete_exchange_not_found(client, make_user, auth_headers):
+    user = make_user()
+    res = client.put("/api/exchanges/9999/complete", headers=auth_headers(user))
+    assert res.status_code == 404
+
+
+# ── DELETE /api/exchanges/<id> ────────────────────────────────────────────────
+
+def test_delete_exchange_success(client, make_user, make_skill, make_exchange,
+                                 auth_headers):
+    offerer = make_user()
+    skill = make_skill()
+    exchange = make_exchange(offerer_id=offerer.id, skill_id=skill.id)
+
+    res = client.delete(f"/api/exchanges/{exchange.id}",
+                        headers=auth_headers(offerer))
+    assert res.status_code == 200
+    assert client.get(f"/api/exchanges/{exchange.id}").status_code == 404
+
+
+def test_delete_exchange_forbidden(client, make_user, make_skill, make_exchange,
+                                   auth_headers):
+    offerer = make_user(email="offerer@test.com")
+    other = make_user(email="other@test.com")
+    skill = make_skill()
+    exchange = make_exchange(offerer_id=offerer.id, skill_id=skill.id)
+
+    res = client.delete(f"/api/exchanges/{exchange.id}",
+                        headers=auth_headers(other))
+    assert res.status_code == 403
+
+
+def test_delete_completed_exchange_rejected(client, make_user, make_skill,
+                                            make_exchange, auth_headers):
+    offerer = make_user()
+    skill = make_skill()
+    exchange = make_exchange(offerer_id=offerer.id, skill_id=skill.id,
+                             is_completed=True)
+
+    res = client.delete(f"/api/exchanges/{exchange.id}",
+                        headers=auth_headers(offerer))
+    assert res.status_code == 400
+
+
+def test_delete_exchange_not_found(client, make_user, auth_headers):
+    user = make_user()
+    res = client.delete("/api/exchanges/9999", headers=auth_headers(user))
+    assert res.status_code == 404

--- a/back/tests/test_messages.py
+++ b/back/tests/test_messages.py
@@ -1,0 +1,169 @@
+"""
+Tests for message endpoints:
+  GET    /api/messages/<user_id>/sent
+  GET    /api/messages/<user_id>/received
+  GET    /api/messages/<id>
+  POST   /api/messages
+  PUT    /api/messages/<id>
+  DELETE /api/messages/<id>
+"""
+
+
+# ── GET endpoints ─────────────────────────────────────────────────────────────
+
+def test_get_sent_messages(client, make_user, make_message):
+    sender = make_user(email="sender@test.com")
+    receiver = make_user(email="receiver@test.com")
+    make_message(sender_id=sender.id, receiver_id=receiver.id, content="Hi!")
+
+    res = client.get(f"/api/messages/{sender.id}/sent")
+    assert res.status_code == 200
+    assert len(res.get_json()["data"]) == 1
+
+
+def test_get_received_messages(client, make_user, make_message):
+    sender = make_user(email="sender@test.com")
+    receiver = make_user(email="receiver@test.com")
+    make_message(sender_id=sender.id, receiver_id=receiver.id)
+
+    res = client.get(f"/api/messages/{receiver.id}/received")
+    assert res.status_code == 200
+    assert len(res.get_json()["data"]) == 1
+
+
+def test_get_message_found(client, make_user, make_message):
+    sender = make_user(email="sender@test.com")
+    receiver = make_user(email="receiver@test.com")
+    msg = make_message(sender_id=sender.id, receiver_id=receiver.id)
+
+    res = client.get(f"/api/messages/{msg.id}")
+    assert res.status_code == 200
+    assert res.get_json()["data"]["content"] == "Hola!"
+
+
+def test_get_message_not_found(client):
+    res = client.get("/api/messages/9999")
+    assert res.status_code == 404
+
+
+# ── POST /api/messages ────────────────────────────────────────────────────────
+
+def test_create_message_success(client, make_user, auth_headers):
+    sender = make_user(email="sender@test.com")
+    receiver = make_user(email="receiver@test.com")
+    res = client.post("/api/messages",
+                      json={
+                          "content": "Hola!",
+                          "sender_id": sender.id,
+                          "receiver_id": receiver.id,
+                      },
+                      headers=auth_headers(sender))
+    assert res.status_code == 201
+    assert res.get_json()["data"]["content"] == "Hola!"
+
+
+def test_create_message_forbidden(client, make_user, auth_headers):
+    sender = make_user(email="sender@test.com")
+    other = make_user(email="other@test.com")
+    receiver = make_user(email="receiver@test.com")
+    res = client.post("/api/messages",
+                      json={
+                          "content": "Hack",
+                          "sender_id": sender.id,
+                          "receiver_id": receiver.id,
+                      },
+                      headers=auth_headers(other))
+    assert res.status_code == 403
+
+
+def test_create_message_missing_content(client, make_user, auth_headers):
+    sender = make_user(email="sender@test.com")
+    receiver = make_user(email="receiver@test.com")
+    res = client.post("/api/messages",
+                      json={"sender_id": sender.id, "receiver_id": receiver.id},
+                      headers=auth_headers(sender))
+    assert res.status_code == 400
+
+
+def test_create_message_no_token(client, make_user):
+    sender = make_user(email="sender@test.com")
+    receiver = make_user(email="receiver@test.com")
+    res = client.post("/api/messages",
+                      json={
+                          "content": "Hi",
+                          "sender_id": sender.id,
+                          "receiver_id": receiver.id,
+                      })
+    assert res.status_code == 401
+
+
+# ── PUT /api/messages/<id> ────────────────────────────────────────────────────
+
+def test_update_message_success(client, make_user, make_message, auth_headers):
+    sender = make_user(email="sender@test.com")
+    receiver = make_user(email="receiver@test.com")
+    msg = make_message(sender_id=sender.id, receiver_id=receiver.id)
+
+    res = client.put(f"/api/messages/{msg.id}",
+                     json={"content": "Actualizado"},
+                     headers=auth_headers(sender))
+    assert res.status_code == 200
+    body = res.get_json()["data"]
+    assert body["content"] == "Actualizado"
+    assert body["seen"] is False
+
+
+def test_update_message_resets_seen(client, make_user, make_message, auth_headers):
+    """Editing content should reset seen to False."""
+    from back.models import db, Message
+    sender = make_user(email="sender@test.com")
+    receiver = make_user(email="receiver@test.com")
+    msg = make_message(sender_id=sender.id, receiver_id=receiver.id)
+    msg.seen = True
+    db.session.commit()
+
+    res = client.put(f"/api/messages/{msg.id}",
+                     json={"content": "Nuevo contenido"},
+                     headers=auth_headers(sender))
+    assert res.status_code == 200
+    assert res.get_json()["data"]["seen"] is False
+
+
+def test_update_message_forbidden(client, make_user, make_message, auth_headers):
+    sender = make_user(email="sender@test.com")
+    other = make_user(email="other@test.com")
+    receiver = make_user(email="receiver@test.com")
+    msg = make_message(sender_id=sender.id, receiver_id=receiver.id)
+
+    res = client.put(f"/api/messages/{msg.id}",
+                     json={"content": "Hack"},
+                     headers=auth_headers(other))
+    assert res.status_code == 403
+
+
+# ── DELETE /api/messages/<id> ─────────────────────────────────────────────────
+
+def test_delete_message_success(client, make_user, make_message, auth_headers):
+    sender = make_user(email="sender@test.com")
+    receiver = make_user(email="receiver@test.com")
+    msg = make_message(sender_id=sender.id, receiver_id=receiver.id)
+
+    res = client.delete(f"/api/messages/{msg.id}", headers=auth_headers(sender))
+    assert res.status_code == 200
+    assert client.get(f"/api/messages/{msg.id}").status_code == 404
+
+
+def test_delete_message_forbidden(client, make_user, make_message, auth_headers):
+    sender = make_user(email="sender@test.com")
+    other = make_user(email="other@test.com")
+    receiver = make_user(email="receiver@test.com")
+    msg = make_message(sender_id=sender.id, receiver_id=receiver.id)
+
+    res = client.delete(f"/api/messages/{msg.id}", headers=auth_headers(other))
+    assert res.status_code == 403
+
+
+def test_delete_message_not_found(client, make_user, auth_headers):
+    user = make_user()
+    res = client.delete("/api/messages/9999", headers=auth_headers(user))
+    assert res.status_code == 404

--- a/back/tests/test_ratings.py
+++ b/back/tests/test_ratings.py
@@ -1,0 +1,283 @@
+"""
+Tests for rating endpoints — constraints are the main focus:
+  GET    /api/ratings
+  GET    /api/ratings/<id>
+  POST   /api/ratings
+  PUT    /api/ratings/<id>
+  DELETE /api/ratings/<id>
+"""
+
+
+# ── GET endpoints ─────────────────────────────────────────────────────────────
+
+def test_get_ratings_empty(client):
+    res = client.get("/api/ratings")
+    assert res.status_code == 200
+    assert res.get_json()["data"] == []
+
+
+def test_get_ratings_list(client, make_user, make_skill, make_exchange,
+                          make_rating):
+    offerer = make_user(email="offerer@test.com")
+    demander = make_user(email="demander@test.com")
+    skill = make_skill()
+    exchange = make_exchange(offerer_id=offerer.id, skill_id=skill.id,
+                             demander_id=demander.id)
+    make_rating(exchange_id=exchange.id, rater_id=offerer.id,
+                rated_id=demander.id, score=4)
+
+    res = client.get("/api/ratings")
+    assert res.status_code == 200
+    assert len(res.get_json()["data"]) == 1
+
+
+def test_get_rating_found(client, make_user, make_skill, make_exchange,
+                          make_rating):
+    offerer = make_user(email="offerer@test.com")
+    demander = make_user(email="demander@test.com")
+    skill = make_skill()
+    exchange = make_exchange(offerer_id=offerer.id, skill_id=skill.id,
+                             demander_id=demander.id)
+    rating = make_rating(exchange_id=exchange.id, rater_id=offerer.id,
+                         rated_id=demander.id, score=4)
+
+    res = client.get(f"/api/ratings/{rating.id}")
+    assert res.status_code == 200
+    assert res.get_json()["data"]["score"] == 4
+
+
+def test_get_rating_not_found(client):
+    res = client.get("/api/ratings/9999")
+    assert res.status_code == 404
+
+
+# ── POST /api/ratings ─────────────────────────────────────────────────────────
+
+def test_create_rating_success(client, make_user, make_skill, make_exchange,
+                               auth_headers):
+    offerer = make_user(email="offerer@test.com")
+    demander = make_user(email="demander@test.com")
+    skill = make_skill()
+    exchange = make_exchange(offerer_id=offerer.id, skill_id=skill.id,
+                             demander_id=demander.id)
+
+    res = client.post("/api/ratings",
+                      json={
+                          "exchange_id": exchange.id,
+                          "rater_id": offerer.id,
+                          "score": 5,
+                      },
+                      headers=auth_headers(offerer))
+    assert res.status_code == 201
+    assert "id" in res.get_json()["data"]
+
+
+def test_create_rating_duplicate_rejected(client, make_user, make_skill,
+                                          make_exchange, make_rating,
+                                          auth_headers):
+    """Unique constraint (exchange_id, rater_id) must be enforced."""
+    offerer = make_user(email="offerer@test.com")
+    demander = make_user(email="demander@test.com")
+    skill = make_skill()
+    exchange = make_exchange(offerer_id=offerer.id, skill_id=skill.id,
+                             demander_id=demander.id)
+    make_rating(exchange_id=exchange.id, rater_id=offerer.id,
+                rated_id=demander.id, score=4)
+
+    res = client.post("/api/ratings",
+                      json={
+                          "exchange_id": exchange.id,
+                          "rater_id": offerer.id,
+                          "score": 5,
+                      },
+                      headers=auth_headers(offerer))
+    assert res.status_code == 400
+
+
+def test_create_rating_no_demander(client, make_user, make_skill, make_exchange,
+                                   auth_headers):
+    """Exchange without demander cannot be rated."""
+    offerer = make_user()
+    skill = make_skill()
+    exchange = make_exchange(offerer_id=offerer.id, skill_id=skill.id)
+
+    res = client.post("/api/ratings",
+                      json={
+                          "exchange_id": exchange.id,
+                          "rater_id": offerer.id,
+                          "score": 5,
+                      },
+                      headers=auth_headers(offerer))
+    assert res.status_code == 400
+
+
+def test_create_rating_score_too_low(client, make_user, make_skill,
+                                     make_exchange, auth_headers):
+    offerer = make_user(email="offerer@test.com")
+    demander = make_user(email="demander@test.com")
+    skill = make_skill()
+    exchange = make_exchange(offerer_id=offerer.id, skill_id=skill.id,
+                             demander_id=demander.id)
+
+    res = client.post("/api/ratings",
+                      json={
+                          "exchange_id": exchange.id,
+                          "rater_id": offerer.id,
+                          "score": 0,
+                      },
+                      headers=auth_headers(offerer))
+    assert res.status_code == 400
+
+
+def test_create_rating_score_too_high(client, make_user, make_skill,
+                                      make_exchange, auth_headers):
+    offerer = make_user(email="offerer@test.com")
+    demander = make_user(email="demander@test.com")
+    skill = make_skill()
+    exchange = make_exchange(offerer_id=offerer.id, skill_id=skill.id,
+                             demander_id=demander.id)
+
+    res = client.post("/api/ratings",
+                      json={
+                          "exchange_id": exchange.id,
+                          "rater_id": offerer.id,
+                          "score": 6,
+                      },
+                      headers=auth_headers(offerer))
+    assert res.status_code == 400
+
+
+def test_create_rating_forbidden(client, make_user, make_skill, make_exchange,
+                                 auth_headers):
+    offerer = make_user(email="offerer@test.com")
+    demander = make_user(email="demander@test.com")
+    outsider = make_user(email="outsider@test.com")
+    skill = make_skill()
+    exchange = make_exchange(offerer_id=offerer.id, skill_id=skill.id,
+                             demander_id=demander.id)
+
+    res = client.post("/api/ratings",
+                      json={
+                          "exchange_id": exchange.id,
+                          "rater_id": offerer.id,
+                          "score": 4,
+                      },
+                      headers=auth_headers(outsider))
+    assert res.status_code == 403
+
+
+def test_create_rating_no_token(client, make_user, make_skill, make_exchange):
+    offerer = make_user(email="offerer@test.com")
+    demander = make_user(email="demander@test.com")
+    skill = make_skill()
+    exchange = make_exchange(offerer_id=offerer.id, skill_id=skill.id,
+                             demander_id=demander.id)
+
+    res = client.post("/api/ratings",
+                      json={
+                          "exchange_id": exchange.id,
+                          "rater_id": offerer.id,
+                          "score": 4,
+                      })
+    assert res.status_code == 401
+
+
+# ── PUT /api/ratings/<id> ─────────────────────────────────────────────────────
+
+def test_update_rating_success(client, make_user, make_skill, make_exchange,
+                               make_rating, auth_headers):
+    offerer = make_user(email="offerer@test.com")
+    demander = make_user(email="demander@test.com")
+    skill = make_skill()
+    exchange = make_exchange(offerer_id=offerer.id, skill_id=skill.id,
+                             demander_id=demander.id)
+    rating = make_rating(exchange_id=exchange.id, rater_id=offerer.id,
+                         rated_id=demander.id, score=3)
+
+    res = client.put(f"/api/ratings/{rating.id}",
+                     json={"score": 5, "comment": "Excelente"},
+                     headers=auth_headers(offerer))
+    assert res.status_code == 200
+    body = res.get_json()["data"]
+    assert body["score"] == 5
+    assert body["comment"] == "Excelente"
+
+
+def test_update_rating_forbidden(client, make_user, make_skill, make_exchange,
+                                 make_rating, auth_headers):
+    offerer = make_user(email="offerer@test.com")
+    demander = make_user(email="demander@test.com")
+    skill = make_skill()
+    exchange = make_exchange(offerer_id=offerer.id, skill_id=skill.id,
+                             demander_id=demander.id)
+    rating = make_rating(exchange_id=exchange.id, rater_id=offerer.id,
+                         rated_id=demander.id, score=3)
+
+    res = client.put(f"/api/ratings/{rating.id}",
+                     json={"score": 1},
+                     headers=auth_headers(demander))
+    assert res.status_code == 403
+
+
+def test_update_rating_score_out_of_range(client, make_user, make_skill,
+                                          make_exchange, make_rating,
+                                          auth_headers):
+    offerer = make_user(email="offerer@test.com")
+    demander = make_user(email="demander@test.com")
+    skill = make_skill()
+    exchange = make_exchange(offerer_id=offerer.id, skill_id=skill.id,
+                             demander_id=demander.id)
+    rating = make_rating(exchange_id=exchange.id, rater_id=offerer.id,
+                         rated_id=demander.id, score=3)
+
+    res = client.put(f"/api/ratings/{rating.id}",
+                     json={"score": 10},
+                     headers=auth_headers(offerer))
+    assert res.status_code == 400
+
+
+def test_update_rating_not_found(client, make_user, auth_headers):
+    user = make_user()
+    res = client.put("/api/ratings/9999",
+                     json={"score": 5},
+                     headers=auth_headers(user))
+    assert res.status_code == 404
+
+
+# ── DELETE /api/ratings/<id> ──────────────────────────────────────────────────
+
+def test_delete_rating_success(client, make_user, make_skill, make_exchange,
+                               make_rating, auth_headers):
+    offerer = make_user(email="offerer@test.com")
+    demander = make_user(email="demander@test.com")
+    skill = make_skill()
+    exchange = make_exchange(offerer_id=offerer.id, skill_id=skill.id,
+                             demander_id=demander.id)
+    rating = make_rating(exchange_id=exchange.id, rater_id=offerer.id,
+                         rated_id=demander.id, score=4)
+
+    res = client.delete(f"/api/ratings/{rating.id}",
+                        headers=auth_headers(offerer))
+    assert res.status_code == 200
+    assert client.get(f"/api/ratings/{rating.id}").status_code == 404
+
+
+def test_delete_rating_forbidden(client, make_user, make_skill, make_exchange,
+                                 make_rating, auth_headers):
+    offerer = make_user(email="offerer@test.com")
+    demander = make_user(email="demander@test.com")
+    skill = make_skill()
+    exchange = make_exchange(offerer_id=offerer.id, skill_id=skill.id,
+                             demander_id=demander.id)
+    rating = make_rating(exchange_id=exchange.id, rater_id=offerer.id,
+                         rated_id=demander.id, score=4)
+
+    res = client.delete(f"/api/ratings/{rating.id}",
+                        headers=auth_headers(demander))
+    assert res.status_code == 403
+
+
+def test_delete_rating_not_found(client, make_user, auth_headers):
+    user = make_user()
+    res = client.delete("/api/ratings/9999", headers=auth_headers(user))
+    assert res.status_code == 404

--- a/back/tests/test_skills.py
+++ b/back/tests/test_skills.py
@@ -1,0 +1,124 @@
+"""
+Tests for skill endpoints:
+  GET    /api/skills
+  GET    /api/skills/<id>
+  GET    /api/skills/category/<category_id>
+  POST   /api/skills
+  PUT    /api/skills/<id>
+  DELETE /api/skills/<id>
+"""
+
+
+# ── GET endpoints ─────────────────────────────────────────────────────────────
+
+def test_get_skills_empty(client):
+    res = client.get("/api/skills")
+    assert res.status_code == 200
+    assert res.get_json()["data"] == []
+
+
+def test_get_skills_list(client, make_skill):
+    make_skill(name="Python")
+    make_skill(name="JavaScript")
+    res = client.get("/api/skills")
+    assert res.status_code == 200
+    assert len(res.get_json()["data"]) == 2
+
+
+def test_get_skill_found(client, make_skill):
+    skill = make_skill(name="Python")
+    res = client.get(f"/api/skills/{skill.id}")
+    assert res.status_code == 200
+    assert res.get_json()["data"]["name"] == "Python"
+
+
+def test_get_skill_not_found(client):
+    res = client.get("/api/skills/9999")
+    assert res.status_code == 404
+
+
+def test_get_skills_by_category(client, make_category, make_skill):
+    cat = make_category(name="Tecnología")
+    make_skill(name="Python", category_id=cat.id)
+    make_skill(name="Go", category_id=cat.id)
+    other_cat = make_category(name="Arte")
+    make_skill(name="Dibujo", category_id=other_cat.id)
+
+    res = client.get(f"/api/skills/category/{cat.id}")
+    assert res.status_code == 200
+    assert len(res.get_json()["data"]) == 2
+
+
+# ── POST /api/skills ──────────────────────────────────────────────────────────
+
+def test_create_skill_success(client, make_category, auth_headers, make_user):
+    user = make_user()
+    cat = make_category(name="Tecnología")
+    res = client.post("/api/skills",
+                      json={"name": "Python", "category_id": cat.id},
+                      headers=auth_headers(user))
+    assert res.status_code == 201
+    assert "id" in res.get_json()["data"]
+
+
+def test_create_skill_missing_name(client, make_category, auth_headers,
+                                   make_user):
+    user = make_user()
+    cat = make_category()
+    res = client.post("/api/skills",
+                      json={"category_id": cat.id},
+                      headers=auth_headers(user))
+    assert res.status_code == 400
+
+
+def test_create_skill_missing_category_id(client, auth_headers, make_user):
+    user = make_user()
+    res = client.post("/api/skills",
+                      json={"name": "Python"},
+                      headers=auth_headers(user))
+    assert res.status_code == 400
+
+
+def test_create_skill_no_token(client, make_category):
+    cat = make_category()
+    res = client.post("/api/skills",
+                      json={"name": "Python", "category_id": cat.id})
+    assert res.status_code == 401
+
+
+# ── PUT /api/skills/<id> ──────────────────────────────────────────────────────
+
+def test_update_skill_success(client, make_skill, make_category, auth_headers,
+                              make_user):
+    user = make_user()
+    skill = make_skill(name="Python")
+    new_cat = make_category(name="Nueva Cat")
+    res = client.put(f"/api/skills/{skill.id}",
+                     json={"description": "Lenguaje versátil",
+                           "category_id": new_cat.id},
+                     headers=auth_headers(user))
+    assert res.status_code == 200
+    assert res.get_json()["data"]["description"] == "Lenguaje versátil"
+
+
+def test_update_skill_no_token(client, make_skill):
+    skill = make_skill()
+    res = client.put(f"/api/skills/{skill.id}",
+                     json={"description": "desc"})
+    assert res.status_code == 401
+
+
+# ── DELETE /api/skills/<id> ───────────────────────────────────────────────────
+
+def test_delete_skill_success(client, make_skill, auth_headers, make_user):
+    user = make_user()
+    skill = make_skill()
+    res = client.delete(f"/api/skills/{skill.id}", headers=auth_headers(user))
+    assert res.status_code == 200
+    assert client.get(f"/api/skills/{skill.id}").status_code == 404
+
+
+def test_delete_skill_no_token(client, make_skill):
+    skill = make_skill()
+    res = client.delete(f"/api/skills/{skill.id}")
+    assert res.status_code == 401

--- a/back/tests/test_users.py
+++ b/back/tests/test_users.py
@@ -1,0 +1,232 @@
+"""
+Tests for user endpoints:
+  GET    /api/users
+  GET    /api/users/<id>
+  GET    /api/users/category/<id>
+  POST   /api/users
+  PUT    /api/users/<id>
+  DELETE /api/users/<id>
+  POST   /api/users/<id>/skill
+"""
+
+
+# ── GET /api/users ────────────────────────────────────────────────────────────
+
+def test_get_users_empty(client):
+    res = client.get("/api/users")
+    assert res.status_code == 200
+    assert res.get_json()["data"] == []
+
+
+def test_get_users_returns_list(client, make_user):
+    make_user(email="a@test.com")
+    make_user(email="b@test.com")
+    res = client.get("/api/users")
+    assert res.status_code == 200
+    data = res.get_json()["data"]
+    assert len(data) == 2
+    assert "rating_average" in data[0]
+
+
+# ── GET /api/users/<id> ───────────────────────────────────────────────────────
+
+def test_get_user_found(client, make_user, make_skill):
+    skill = make_skill()
+    user = make_user()
+    user.skills.append(skill)
+    from back.models import db
+    db.session.commit()
+
+    res = client.get(f"/api/users/{user.id}")
+    assert res.status_code == 200
+    body = res.get_json()["data"]
+    assert body["email"] == user.email
+    assert len(body["skills"]) == 1
+
+
+def test_get_user_not_found(client):
+    res = client.get("/api/users/9999")
+    assert res.status_code == 404
+
+
+# ── GET /api/users/category/<id> ──────────────────────────────────────────────
+
+def test_get_users_by_category(client, make_user, make_category, make_skill):
+    cat = make_category(name="Tecnología")
+    skill = make_skill(name="Python", category_id=cat.id)
+    user = make_user()
+    user.skills.append(skill)
+    from back.models import db
+    db.session.commit()
+
+    res = client.get(f"/api/users/category/{cat.id}")
+    assert res.status_code == 200
+    assert len(res.get_json()["data"]) == 1
+
+
+def test_get_users_by_category_no_skills(client, make_category):
+    cat = make_category()
+    res = client.get(f"/api/users/category/{cat.id}")
+    assert res.status_code == 200
+    assert res.get_json()["data"] == []
+
+
+# ── POST /api/users ───────────────────────────────────────────────────────────
+
+def test_create_user_success(client):
+    res = client.post("/api/users", json={
+        "first_name": "Ana",
+        "last_name": "García",
+        "email": "ana@test.com",
+        "password": "secure123",
+        "accepts_terms": True,
+    })
+    assert res.status_code == 201
+    assert "id" in res.get_json()["data"]
+
+
+def test_create_user_duplicate_email(client, make_user):
+    make_user(email="ana@test.com")
+    res = client.post("/api/users", json={
+        "first_name": "Ana",
+        "last_name": "García",
+        "email": "ana@test.com",
+        "password": "secure123",
+        "accepts_terms": True,
+    })
+    assert res.status_code == 400
+
+
+def test_create_user_missing_required_field(client):
+    res = client.post("/api/users", json={
+        "last_name": "García",
+        "email": "ana@test.com",
+        "password": "secure123",
+        "accepts_terms": True,
+    })
+    assert res.status_code == 400
+
+
+def test_create_user_weak_password(client):
+    res = client.post("/api/users", json={
+        "first_name": "Ana",
+        "last_name": "García",
+        "email": "ana@test.com",
+        "password": "short",
+        "accepts_terms": True,
+    })
+    assert res.status_code == 400
+
+
+def test_create_user_invalid_email(client):
+    res = client.post("/api/users", json={
+        "first_name": "Ana",
+        "last_name": "García",
+        "email": "not-an-email",
+        "password": "secure123",
+        "accepts_terms": True,
+    })
+    assert res.status_code == 400
+
+
+# ── PUT /api/users/<id> ───────────────────────────────────────────────────────
+
+def test_update_user_success(client, make_user, auth_headers):
+    user = make_user()
+    res = client.put(f"/api/users/{user.id}",
+                     json={"first_name": "Nuevo"},
+                     headers=auth_headers(user))
+    assert res.status_code == 200
+    assert res.get_json()["data"]["first_name"] == "Nuevo"
+
+
+def test_update_user_forbidden(client, make_user, auth_headers):
+    owner = make_user(email="owner@test.com")
+    other = make_user(email="other@test.com")
+    res = client.put(f"/api/users/{owner.id}",
+                     json={"first_name": "Hack"},
+                     headers=auth_headers(other))
+    assert res.status_code == 403
+
+
+def test_update_user_no_token(client, make_user):
+    user = make_user()
+    res = client.put(f"/api/users/{user.id}", json={"first_name": "Nuevo"})
+    assert res.status_code == 401
+
+
+def test_update_user_duplicate_email(client, make_user, auth_headers):
+    user1 = make_user(email="user1@test.com")
+    make_user(email="user2@test.com")
+    res = client.put(f"/api/users/{user1.id}",
+                     json={"email": "user2@test.com"},
+                     headers=auth_headers(user1))
+    assert res.status_code == 400
+
+
+# ── DELETE /api/users/<id> ────────────────────────────────────────────────────
+
+def test_delete_user_success(client, make_user, auth_headers):
+    user = make_user()
+    res = client.delete(f"/api/users/{user.id}", headers=auth_headers(user))
+    assert res.status_code == 200
+    assert client.get(f"/api/users/{user.id}").status_code == 404
+
+
+def test_delete_user_forbidden(client, make_user, auth_headers):
+    owner = make_user(email="owner@test.com")
+    other = make_user(email="other@test.com")
+    res = client.delete(f"/api/users/{owner.id}", headers=auth_headers(other))
+    assert res.status_code == 403
+
+
+def test_delete_user_no_token(client, make_user):
+    user = make_user()
+    res = client.delete(f"/api/users/{user.id}")
+    assert res.status_code == 401
+
+
+# ── POST /api/users/<id>/skill ────────────────────────────────────────────────
+
+def test_associate_skill_success(client, make_user, make_skill, auth_headers):
+    user = make_user()
+    skill = make_skill()
+    res = client.post(f"/api/users/{user.id}/skill",
+                      json={"associate": skill.id},
+                      headers=auth_headers(user))
+    assert res.status_code == 201
+    skills = res.get_json()["data"]["skills"]
+    assert any(s["id"] == skill.id for s in skills)
+
+
+def test_disassociate_skill_success(client, make_user, make_skill, auth_headers):
+    user = make_user()
+    skill = make_skill()
+    user.skills.append(skill)
+    from back.models import db
+    db.session.commit()
+
+    res = client.post(f"/api/users/{user.id}/skill",
+                      json={"disassociate": skill.id},
+                      headers=auth_headers(user))
+    assert res.status_code == 201
+    skills = res.get_json()["data"]["skills"]
+    assert not any(s["id"] == skill.id for s in skills)
+
+
+def test_associate_skill_forbidden(client, make_user, make_skill, auth_headers):
+    owner = make_user(email="owner@test.com")
+    other = make_user(email="other@test.com")
+    skill = make_skill()
+    res = client.post(f"/api/users/{owner.id}/skill",
+                      json={"associate": skill.id},
+                      headers=auth_headers(other))
+    assert res.status_code == 403
+
+
+def test_associate_skill_not_found(client, make_user, auth_headers):
+    user = make_user()
+    res = client.post(f"/api/users/{user.id}/skill",
+                      json={"associate": 9999},
+                      headers=auth_headers(user))
+    assert res.status_code == 404

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+testpaths = back/tests
+python_files = test_*.py
+python_functions = test_*
+addopts = -v


### PR DESCRIPTION
## Summary

- Added `pytest`, `pytest-flask`, `pytest-cov` to `Pipfile` dev-packages and `requirements.txt`
- Added `pytest.ini` with `testpaths = back/tests` and `-v` flag
- Added `test` and `test-cov` scripts to `Pipfile`
- `back/tests/conftest.py`: function-scoped `app` fixture using SQLite in-memory + `StaticPool` (no external DB needed), factory helpers for all models, `auth_headers` helper
- 7 test files (~100 tests) covering all critical paths:
  - `test_auth`: login, `/me`, refresh, Google OAuth (mocked), logout
  - `test_users`: CRUD, skill association, ownership checks
  - `test_messages`: CRUD, sender ownership enforcement
  - `test_exchanges`: full lifecycle — create → join → complete → delete
  - `test_ratings`: unique constraint, score range (1–5), no-demander guard
  - `test_skills`, `test_categories`: CRUD + JWT guards
- Cleaned up `requirements.txt`: removed `flask-admin` and `wtforms` (leftover from #11), added `flask-swagger`

Closes #13

## Test plan

- [ ] `docker compose exec backend pytest` — all tests pass
- [ ] `docker compose exec backend pytest --cov=back --cov-report=term-missing` — coverage report visible
- [ ] No external services called (Cloudinary and Google OAuth are mocked)