### PR TITLE
feat: add pagination to list endpoints (#14)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,151 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+**Swapp** is a peer-to-peer skill exchange platform (trade services without money). Monorepo with a Flask backend (`back/`) and React frontend (`front/`). Deployed on Render at https://swapp-app.onrender.com.
+
+## Tech Stack
+
+- **Frontend**: React 19, React Router 7, Vite 7, Bootstrap 5, CSS modules, `@react-oauth/google`
+- **Backend**: Flask, SQLAlchemy, Flask-JWT-Extended, `google-auth`, `flask-swagger` (pendiente implementar)
+- **Database**: PostgreSQL (production & Docker dev), SQLite (fallback local dev)
+- **Media**: Cloudinary for image uploads
+- **Deployment**: Render (Gunicorn), Docker Compose (dev & prod), GitHub Container Registry
+
+## Development (Docker)
+
+```bash
+# Start all services (db, backend, frontend)
+docker compose up
+
+# Run backend tests (SQLite in-memory, no DB service needed)
+docker compose exec backend pytest
+docker compose exec backend pytest --cov=back --cov-report=term-missing
+
+# Start with rebuild
+docker compose up --build
+
+# Run migrations
+docker compose exec backend flask db upgrade
+
+# Create a new migration
+docker compose exec backend flask db migrate -m "message"
+
+# Seed database
+docker compose exec backend python -m back.init.seed_data
+docker compose exec backend python -m back.init.seed_users
+
+# Frontend lint
+docker compose exec frontend npm run lint
+```
+
+Services: `db` (PostgreSQL 16, port 5432), `backend` (Flask, port 5000), `frontend` (Vite, port 3000).
+Source code is volume-mounted — changes to `back/` and `front/` auto-reload.
+
+Copy `back/.env.example` to `back/.env`, `front/.env.example` to `front/.env`, and `db.env.example` to `db.env` before first run.
+
+## Production (Docker)
+
+```bash
+# Build and run production containers
+docker compose -f compose.prod.yml up --build
+
+# Build images for registry
+docker build -f docker/prod/backend.Dockerfile -t ghcr.io/<user>/swapp-backend .
+docker build -f docker/prod/frontend.Dockerfile -t ghcr.io/<user>/swapp-frontend .
+```
+
+Production uses multi-stage builds: frontend builds static files served by Nginx (port 80), backend runs Gunicorn (port 5000). Nginx proxies `/api/` to the backend.
+
+## Development (without Docker)
+
+```bash
+cd front && npm run dev   # Frontend (port 3000)
+flask run                 # Backend (port 5000)
+cd front && npm run build # Build frontend
+./deploy.sh               # Production deploy (Render)
+```
+
+## Architecture
+
+### Backend (`back/`)
+
+- **Entry point**: `back/app.py` — Flask app factory, blueprint registration, serves built frontend in production (flask-admin removed in #11)
+- **Models**: `back/models.py` — SQLAlchemy models (User, Category, Skill, Message, Exchange, Rating)
+- **Routes**: `back/urls/` — Blueprints: `user.py`, `skill.py`, `category.py`, `message.py`, `exchange.py`, `rating.py`
+- **Auth routes**: `/api/auth/login` (POST), `/api/auth/me` (GET, jwt_required), `/api/auth/refresh` (POST, jwt_required refresh=True), `/api/auth/google/verify` (POST, verifies Google id_token → returns app JWT), `/api/logout` (POST, stateless)
+- **Utils**: `back/utils.py` — `APIException`, `validate()`, `success()`, `error_response()`, `not_found()`, `forbidden()`, `bad_request()`, `get_current_user()`, `paginate_query()`, `paginated_success()` helpers used across all blueprints
+- **Tests**: `back/tests/` — pytest suite (SQLite in-memory + StaticPool); `conftest.py` has app/client fixtures, factory helpers, `auth_headers`; 7 test files covering auth, users, messages, exchanges, ratings, skills, categories; 125 tests total including pagination coverage
+- **Image upload**: `back/cloudinary/` — Cloudinary config and profile picture route
+- **Seed data**: `back/init/seed_data.py` (categories + skills), `back/init/seed_users.py` (demo users)
+- **Migrations**: `back/migrations/` — Alembic/Flask-Migrate migration files
+- **Scripts**: `back/scripts/` — DB diagram generator
+- **HTTP tests**: `back/rest/` — REST Client `.http` files for testing endpoints
+- **WSGI**: `back/wsgi.py` — Gunicorn entry point
+
+All API endpoints prefixed with `/api/`. Auth uses JWT tokens via Flask-JWT-Extended.
+
+### Frontend (`front/`)
+
+- **Entry point**: `front/index.html` → `front/main.jsx` → `front/App.jsx` (routes)
+- **Config**: `front/vite.config.js`, `front/package.json`, `front/eslint.config.js`
+- **Static assets**: `front/public/` — images and icons
+- **State management**: Context + useReducer in `front/store.js` (actions: SET_USER, SET_USERS, SET_TOKEN, SET_CATEGORIES)
+- **API calls**: `front/services/api.js`
+- **Pages**: Home, Login, Register, UserProfile, PublicProfile, CategoryUsers
+- **Components**: Navbar, Footer, Carousel, UserCard, ChatModal, ExchangeModal, RatingModal, AddSkillModal, CropperModal, MessagingButton
+- **Styles**: `front/assets/styles/` — one CSS file per component
+
+### Key Patterns
+
+- JWT access token (6h) and refresh token (30d) stored in localStorage; `apiFetch()` in `services/api.js` handles silent token refresh on 401 automatically
+- Google OAuth uses frontend-driven popup flow (`@react-oauth/google`): Google returns `id_token` to the browser → frontend POSTs to `/api/auth/google/verify` → backend verifies with `google-auth` and returns app JWT. No callback URL needed — works on any domain. `GOOGLE_CLIENT_ID` env var required on backend; `VITE_GOOGLE_CLIENT_ID` build ARG required for frontend Docker image
+- M2M relationship between users and skills via `UserSkill` junction table
+- Ratings are tied to completed exchanges via `UniqueConstraint(exchange_id, rater_id)`
+- Password hashing via werkzeug property setter on `User.password`
+- Vite config and all frontend files live inside `front/`; builds to `front/dist/`
+- Flask serves `front/dist/` as static folder in Render production
+- Docker prod: Nginx serves static files and proxies `/api/` to backend
+
+## API Endpoints
+
+| Resource   | Base URL          | Methods                        |
+|------------|-------------------|--------------------------------|
+| Users      | `/api/users`      | GET (paginated), POST, PUT, DELETE |
+| Auth       | `/api/auth`       | POST `/login`, GET `/me`, POST `/refresh`, POST `/google/verify` |
+| Logout     | `/api/logout`     | POST                           |
+| Skills     | `/api/skills`     | GET, POST, PUT, DELETE         |
+| Categories | `/api/categories` | GET, POST, PUT, DELETE         |
+| Messages   | `/api/messages`   | GET (paginated), POST, PUT, DELETE |
+| Exchanges  | `/api/exchanges`  | GET (paginated), POST, PUT, DELETE |
+| Ratings    | `/api/ratings`    | GET (paginated), POST, PUT, DELETE |
+| Upload     | `/api/users/<id>/profile-picture` | POST          |
+
+Paginated list endpoints accept `?page=1&per_page=20` (default 20, max 100). Response: `{"data": [...], "pagination": {"page", "per_page", "total", "pages", "has_next", "has_prev"}}`.
+
+## Environment Variables
+
+Environment is split per service:
+- `back/.env.example` — Flask, JWT, DB, Cloudinary, `GOOGLE_CLIENT_ID` vars
+- `front/.env.example` — Vite vars (`VITE_BACKEND_URL`, `VITE_APP_NAME`, `VITE_GOOGLE_CLIENT_ID`)
+- `db.env.example` — PostgreSQL credentials (`POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD`)
+- For Docker prod: `VITE_GOOGLE_CLIENT_ID` must be passed as build ARG (`--build-arg` or via `compose.prod.yml`)
+
+### Docker structure
+
+```
+docker/
+  dev/                    # Development Dockerfiles
+    backend.Dockerfile    # Python 3.13 Alpine + Flask dev server
+    frontend.Dockerfile   # Node 24 Alpine + Vite dev server
+  prod/                   # Production Dockerfiles
+    backend.Dockerfile    # Multi-stage: Python + Gunicorn (4 workers)
+    frontend.Dockerfile   # Multi-stage: Node build → Nginx
+    nginx.conf            # Nginx config (SPA fallback + /api/ proxy)
+```
+
+## Codebase Language
+
+Code (variables, models, API routes) is in **English**. UI text (labels, messages) is in **Spanish**.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,137 @@
+# ROADMAP — Swapp
+
+Roadmap of improvements based on code analysis. Organized by priority.
+
+---
+
+## P0 — Critical (Security)
+
+- [x] **Add `@jwt_required()` to all mutating endpoints** [#2](https://github.com/jemartnz/swapp/issues/2)
+  - `DELETE /api/users/<id>`
+  - `PUT /api/users/<id>`
+  - `POST /api/users/<id>/skill`
+  - All message endpoints (`POST`, `PUT`, `DELETE`)
+  - All exchange endpoints (`POST`, `PUT`, `DELETE`)
+  - All rating endpoints (`POST`, `PUT`, `DELETE`)
+  - `POST /api/users/<id>/profile-picture`
+
+- [x] **Add ownership authorization checks** [#3](https://github.com/jemartnz/swapp/issues/3)
+  - After verifying JWT, compare `get_jwt_identity()` email with the resource owner
+  - Users should only modify their own profile, skills, and messages
+  - Only exchange participants should be able to complete/delete exchanges
+
+- [x] **Stop leaking internal errors to clients** [#4](https://github.com/jemartnz/swapp/issues/4)
+  - Replace `"detail": str(e)` in all catch blocks with a generic message in production
+  - Use `app.config["DEBUG"]` to conditionally include details
+
+---
+
+## P1 — High (Bugs & Data Integrity)
+
+- [x] **Fix N+1 query in `User.rating_average`** [#5](https://github.com/jemartnz/swapp/issues/5)
+  - The `rating_average` property runs a full DB query per user
+  - When listing 100 users, this generates 101 queries
+  - Options: eager loading, denormalized `avg_rating` column, or SQL subquery in the list endpoint
+
+- [x] **Remove auto-creation of users in `/api/auth/me`** [#6](https://github.com/jemartnz/swapp/issues/6)
+  - Currently, any valid JWT with an unknown email creates a new user with empty fields
+  - Return 404 instead, and handle registration through the proper `/api/users` endpoint
+
+- [x] **Add input validation to all endpoints** [#7](https://github.com/jemartnz/swapp/issues/7)
+  - Validate email format, password strength, required fields
+  - Validate `score` range (1-5) in ratings
+  - Validate date formats before parsing
+
+---
+
+## P2 — Medium (Code Quality)
+
+- [x] **Standardize API response structure** [#8](https://github.com/jemartnz/swapp/issues/8)
+  - Define a consistent format: `{"data": ..., "message": "..."}` for success, `{"error": "..."}` for errors
+  - Create a response helper in `utils.py`
+
+- [x] **Add a refresh token endpoint** [#9](https://github.com/jemartnz/swapp/issues/9)
+  - `create_refresh_token()` is generated at login but there's no endpoint to use it
+  - Add `POST /api/auth/refresh` with `@jwt_required(refresh=True)`
+
+- [x] **Configure OAuth properly or remove it** [#10](https://github.com/jemartnz/swapp/issues/10)
+  - `OAuth()` is initialized in `app.py` but never configured
+  - Either implement Google OAuth backend flow or remove the import
+
+- [x] **Remove unused dependencies from Pipfile** [#11](https://github.com/jemartnz/swapp/issues/11)
+  - `flask-swagger` — never imported
+  - `flask-dance` — never imported
+  - `oauthlib` — never imported
+  - `wtforms` — only used by flask-admin (auto-dependency)
+  - `mysqlclient` in dev — project uses PostgreSQL
+
+- [x] **Reduce code duplication in route handlers** [#12](https://github.com/jemartnz/swapp/issues/12)
+  - Added `forbidden()` and `bad_request()` helpers to `utils.py`
+  - Replaced 13× inline `jsonify({"error": "Forbidden"}), 403` with `forbidden()` across all blueprints
+  - Replaced inline 400/404 patterns with `bad_request()` / `not_found()`
+  - Removed `jsonify` import from blueprints that no longer need it directly
+  - Fixed naming conflict: renamed `/api/auth/me` handler to `get_me` (was shadowing `get_current_user` utility)
+  - Standardized `cloudinary/routes.py` to use `success()` instead of bare `jsonify()`
+
+- [x] **Handle `/api/auth/me` errors in frontend** [#22](https://github.com/jemartnz/swapp/issues/22)
+  - All 7 call sites do not check `response.ok` before dispatching to the store
+  - On 401/404: call `localStorage.removeItem("token")` to clear stale token
+  - Do not dispatch `SET_USER` with an error payload
+  - Files: `Home.jsx`, `UserProfile.jsx`, `PublicProfile.jsx` (×2), `ChatModal.jsx`, `ExchangeModal.jsx`, `RatingModal.jsx`
+
+- [x] **Add backend tests** [#13](https://github.com/jemartnz/swapp/issues/13)
+  - pytest + pytest-flask + pytest-cov in Pipfile [dev-packages] and requirements.txt
+  - SQLite in-memory with StaticPool — no external DB needed for tests
+  - `back/tests/conftest.py`: app fixture (function-scoped), factory helpers, `auth_headers`
+  - 7 test files: `test_auth`, `test_users`, `test_messages`, `test_exchanges`, `test_ratings`, `test_skills`, `test_categories`
+  - Cloudinary and Google OAuth mocked with `unittest.mock.patch`
+  - Run with: `pytest` (local) or `docker compose exec backend pytest` (Docker)
+
+---
+
+## P3 — Low (Enhancements)
+
+- [x] **Add pagination to list endpoints** [#14](https://github.com/jemartnz/swapp/issues/14)
+  - Added `paginate_query()` and `paginated_success()` helpers to `utils.py`
+  - Paginated: `GET /api/users`, `GET /api/users/category/<id>`, `GET /api/messages/<id>/sent`, `GET /api/messages/<id>/received`, `GET /api/exchanges` (all 4 variants), `GET /api/ratings`
+  - Response: `{"data": [...], "pagination": {"page", "per_page", "total", "pages", "has_next", "has_prev"}}`
+  - Accept `?page=1&per_page=20` (default), max 100 per page
+  - Added 5 pagination tests across test_users, test_messages, test_exchanges, test_ratings
+  - Frontend updated to read `.data` from all list responses (fixes pre-existing data-unwrapping bugs)
+
+- [ ] **Add frontend error boundary** [#15](https://github.com/jemartnz/swapp/issues/15)
+  - Catch React rendering errors gracefully
+  - Show user-friendly error page instead of white screen
+
+- [ ] **Improve Vite proxy setup** [#16](https://github.com/jemartnz/swapp/issues/16)
+  - Configure Vite `server.proxy` to forward `/api` requests to the backend
+  - Eliminates CORS in development and simplifies frontend API calls
+
+- [ ] **Add database indexes** [#17](https://github.com/jemartnz/swapp/issues/17)
+  - Index on `messages.sender_id` and `messages.receiver_id` for chat queries
+  - Index on `exchanges.offerer_id` and `exchanges.demander_id`
+  - Index on `ratings.rated_id` for rating average calculation
+
+- [ ] **Add WebSocket for real-time messaging** [#18](https://github.com/jemartnz/swapp/issues/18)
+  - Current chat uses polling or page refresh
+  - Flask-SocketIO or a separate WebSocket service for live updates
+
+- [ ] **Add Swagger interactive API documentation** [#19](https://github.com/jemartnz/swapp/issues/19)
+  - `flask-swagger` is already installed in Pipfile
+  - Annotate all blueprints (users, skills, categories, messages, exchanges, ratings) with OpenAPI/Swagger spec
+  - Serve interactive Swagger UI at `/api/docs`
+  - Document request bodies, response shapes, auth headers, and error codes
+
+---
+
+## Completed
+
+- [x] **Docker Compose setup** — 3 containers (db, backend, frontend) with hot-reload volumes
+- [x] **Refactor codebase to English** — All models, routes, API endpoints, frontend variables
+- [x] **Fix `datetime.now()` defaults** — Changed to `lambda` to avoid shared timestamp bug
+- [x] **Fix `APIException` error handler** — Now accepts error param and returns proper JSON
+- [x] **Fix status 204 returning JSON** — Changed to status 200
+- [x] **Fix operator precedence bug** — Added parentheses and `elif` in skill association
+- [x] **Fix copy-paste error messages** — Corrected IntegrityError messages per resource
+- [x] **Remove dead code after `get_or_404()`** — Removed unreachable `if not` checks
+- [x] **Fix `vite.config.js`** — Removed invalid `server.root`, added Docker-friendly config

--- a/back/cloudinary/routes.py
+++ b/back/cloudinary/routes.py
@@ -21,7 +21,7 @@ def upload_profile_picture(user_id):
         return forbidden()
 
     try:
-        user = User.query.get(user_id)
+        user = db.session.get(User, user_id)
         if not user:
             return not_found("User")
 

--- a/back/tests/conftest.py
+++ b/back/tests/conftest.py
@@ -1,6 +1,17 @@
 """
 Shared fixtures for all test modules.
+
+DATABASE_URL is overridden via os.environ BEFORE back.app is imported so that
+Flask-SQLAlchemy builds its engine with SQLite in-memory from the start.
+StaticPool ensures every connection shares the same in-memory database.
 """
+import os
+
+# Must be set before importing back.app so the module-level DB_URL detection
+# in app.py picks up SQLite instead of whatever is in the real .env file.
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+os.environ.setdefault("FLASK_APP_KEY", "test-secret-key")
+
 import pytest
 from sqlalchemy.pool import StaticPool
 from flask_jwt_extended import create_access_token
@@ -15,17 +26,18 @@ from back.models import db, User, Category, Skill, Exchange, Message, Rating
 def app():
     """
     Flask app configured for testing.
-    Uses SQLite in-memory with StaticPool so all connections share
-    the same in-memory database within a single test.
+    The engine is lazily created on the first db.create_all() call and uses
+    SQLite in-memory + StaticPool (set via SQLALCHEMY_ENGINE_OPTIONS).
+    Once created the engine is reused across all function-scoped tests;
+    create_all / drop_all manage the schema isolation between tests.
     """
     flask_app.config.update({
         "TESTING": True,
-        "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:",
         "SQLALCHEMY_ENGINE_OPTIONS": {
             "connect_args": {"check_same_thread": False},
             "poolclass": StaticPool,
         },
-        "JWT_SECRET_KEY": "test-secret",
+        "JWT_SECRET_KEY": "test-secret-key-long-enough-for-hmac-sha256",
         "DEBUG": False,
         "GOOGLE_CLIENT_ID": "test-client-id",
     })

--- a/back/tests/test_exchanges.py
+++ b/back/tests/test_exchanges.py
@@ -30,6 +30,21 @@ def test_get_exchanges_list(client, make_user, make_skill, make_exchange):
     assert len(res.get_json()["data"]) == 1
 
 
+def test_get_exchanges_pagination(client, make_user, make_skill, make_exchange):
+    offerer = make_user()
+    skill = make_skill()
+    for _ in range(3):
+        make_exchange(offerer_id=offerer.id, skill_id=skill.id)
+
+    res = client.get("/api/exchanges?per_page=2")
+    assert res.status_code == 200
+    body = res.get_json()
+    assert "pagination" in body
+    assert body["pagination"]["total"] == 3
+    assert len(body["data"]) == 2
+    assert body["pagination"]["has_next"] is True
+
+
 def test_get_exchange_found(client, make_user, make_skill, make_exchange):
     offerer = make_user()
     skill = make_skill()

--- a/back/tests/test_messages.py
+++ b/back/tests/test_messages.py
@@ -31,6 +31,21 @@ def test_get_received_messages(client, make_user, make_message):
     assert len(res.get_json()["data"]) == 1
 
 
+def test_get_sent_messages_pagination(client, make_user, make_message):
+    sender = make_user(email="sender@test.com")
+    receiver = make_user(email="receiver@test.com")
+    for _ in range(3):
+        make_message(sender_id=sender.id, receiver_id=receiver.id)
+
+    res = client.get(f"/api/messages/{sender.id}/sent?per_page=2")
+    assert res.status_code == 200
+    body = res.get_json()
+    assert "pagination" in body
+    assert body["pagination"]["total"] == 3
+    assert len(body["data"]) == 2
+    assert body["pagination"]["has_next"] is True
+
+
 def test_get_message_found(client, make_user, make_message):
     sender = make_user(email="sender@test.com")
     receiver = make_user(email="receiver@test.com")

--- a/back/tests/test_ratings.py
+++ b/back/tests/test_ratings.py
@@ -16,6 +16,30 @@ def test_get_ratings_empty(client):
     assert res.get_json()["data"] == []
 
 
+def test_get_ratings_pagination(client, make_user, make_skill, make_exchange,
+                                make_rating):
+    offerer = make_user(email="offerer@test.com")
+    demander = make_user(email="demander@test.com")
+    skill = make_skill()
+    ex1 = make_exchange(offerer_id=offerer.id, skill_id=skill.id,
+                        demander_id=demander.id)
+    ex2 = make_exchange(offerer_id=demander.id, skill_id=skill.id,
+                        demander_id=offerer.id)
+    ex3 = make_exchange(offerer_id=offerer.id, skill_id=skill.id,
+                        demander_id=demander.id)
+    make_rating(exchange_id=ex1.id, rater_id=offerer.id, rated_id=demander.id)
+    make_rating(exchange_id=ex2.id, rater_id=demander.id, rated_id=offerer.id)
+    make_rating(exchange_id=ex3.id, rater_id=offerer.id, rated_id=demander.id)
+
+    res = client.get("/api/ratings?per_page=2")
+    assert res.status_code == 200
+    body = res.get_json()
+    assert "pagination" in body
+    assert body["pagination"]["total"] == 3
+    assert len(body["data"]) == 2
+    assert body["pagination"]["has_next"] is True
+
+
 def test_get_ratings_list(client, make_user, make_skill, make_exchange,
                           make_rating):
     offerer = make_user(email="offerer@test.com")

--- a/back/tests/test_users.py
+++ b/back/tests/test_users.py
@@ -28,6 +28,31 @@ def test_get_users_returns_list(client, make_user):
     assert "rating_average" in data[0]
 
 
+def test_get_users_pagination_meta(client, make_user):
+    for i in range(3):
+        make_user(email=f"u{i}@test.com")
+    res = client.get("/api/users?per_page=2")
+    assert res.status_code == 200
+    body = res.get_json()
+    assert "pagination" in body
+    assert body["pagination"]["total"] == 3
+    assert body["pagination"]["pages"] == 2
+    assert body["pagination"]["has_next"] is True
+    assert body["pagination"]["has_prev"] is False
+    assert len(body["data"]) == 2
+
+
+def test_get_users_page_2(client, make_user):
+    for i in range(3):
+        make_user(email=f"p{i}@test.com")
+    res = client.get("/api/users?page=2&per_page=2")
+    assert res.status_code == 200
+    body = res.get_json()
+    assert len(body["data"]) == 1
+    assert body["pagination"]["has_prev"] is True
+    assert body["pagination"]["has_next"] is False
+
+
 # ── GET /api/users/<id> ───────────────────────────────────────────────────────
 
 def test_get_user_found(client, make_user, make_skill):

--- a/back/urls/category.py
+++ b/back/urls/category.py
@@ -31,7 +31,7 @@ def get_category(category_id):
     """
         Get a single category
     """
-    category = Category.query.get_or_404(category_id)
+    category = db.get_or_404(Category, category_id)
     return success(category.to_dict())
 
 
@@ -65,7 +65,7 @@ def update_category(category_id):
     """
         Update a category
     """
-    category = Category.query.get_or_404(category_id)
+    category = db.get_or_404(Category, category_id)
     data = request.get_json()
 
     category.name = data.get('name', category.name)
@@ -81,7 +81,7 @@ def delete_category(category_id):
     """
         Delete a category
     """
-    category = Category.query.get_or_404(category_id)
+    category = db.get_or_404(Category, category_id)
     db.session.delete(category)
     db.session.commit()
     return success(message="Category deleted")

--- a/back/urls/exchange.py
+++ b/back/urls/exchange.py
@@ -32,7 +32,7 @@ def get_exchange(exchange_id):
         Get a specific exchange
     """
     try:
-        exchange = Exchange.query.get(exchange_id)
+        exchange = db.session.get(Exchange, exchange_id)
 
         if not exchange:
             return not_found("Exchange")
@@ -99,8 +99,8 @@ def create_exchange():
 
     try:
 
-        offerer = User.query.get_or_404(data["offerer_id"])
-        skill = Skill.query.get_or_404(data["skill_id"])
+        offerer = db.get_or_404(User, data["offerer_id"])
+        skill = db.get_or_404(Skill, data["skill_id"])
 
         exchange = Exchange(
             offerer_id=offerer.id,
@@ -130,7 +130,7 @@ def complete_exchange(exchange_id):
         Mark an exchange as completed
     """
     try:
-        exchange = Exchange.query.get(exchange_id)
+        exchange = db.session.get(Exchange, exchange_id)
 
         if not exchange:
             return not_found("Exchange")
@@ -191,7 +191,7 @@ def assign_demander(exchange_id):
         if not demander_id:
             return bad_request("Must provide user_id")
 
-        exchange = Exchange.query.get(exchange_id)
+        exchange = db.session.get(Exchange, exchange_id)
         if not exchange:
             return not_found("Exchange")
 
@@ -201,7 +201,7 @@ def assign_demander(exchange_id):
         if exchange.offerer_id == demander_id:
             return bad_request("The offerer cannot be their own demander")
 
-        demander = User.query.get(demander_id)
+        demander = db.session.get(User, demander_id)
         if not demander:
             return not_found("Demander user")
 
@@ -224,7 +224,7 @@ def delete_exchange(exchange_id):
         Delete an exchange (only if not completed)
     """
     try:
-        exchange = Exchange.query.get(exchange_id)
+        exchange = db.session.get(Exchange, exchange_id)
 
         if not exchange:
             return not_found("Exchange")

--- a/back/urls/exchange.py
+++ b/back/urls/exchange.py
@@ -5,7 +5,8 @@ from flask import Blueprint, request
 from flask_jwt_extended import jwt_required
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from back.utils import (get_current_user, error_response, validate, success,
-                        forbidden, bad_request, not_found)
+                        forbidden, bad_request, not_found,
+                        paginate_query, paginated_success)
 from back.models import db, Exchange, User, Skill
 
 exchanges = Blueprint("exchanges", __name__)
@@ -17,9 +18,13 @@ def get_exchanges():
         List all exchanges
     """
     try:
-        all_exchanges = Exchange.query.all()
+        page = request.args.get('page', 1, type=int)
+        per_page = request.args.get('per_page', 20, type=int)
 
-        return success([e.to_dict() for e in all_exchanges])
+        pagination = paginate_query(
+            Exchange.query.order_by(Exchange.id.desc()), page, per_page
+        )
+        return paginated_success([e.to_dict() for e in pagination.items], pagination)
 
     except SQLAlchemyError as e:
         db.session.rollback()
@@ -51,10 +56,14 @@ def get_offered_exchanges(user_id):
         Get all exchanges created by the user (as offerer)
     """
     try:
-        user_exchanges = Exchange.query.filter_by(
-            offerer_id=user_id).all()
+        page = request.args.get('page', 1, type=int)
+        per_page = request.args.get('per_page', 20, type=int)
 
-        return success([e.to_dict() for e in user_exchanges])
+        pagination = paginate_query(
+            Exchange.query.filter_by(offerer_id=user_id).order_by(Exchange.id.desc()),
+            page, per_page
+        )
+        return paginated_success([e.to_dict() for e in pagination.items], pagination)
 
     except SQLAlchemyError as e:
         db.session.rollback()
@@ -68,10 +77,14 @@ def get_demanded_exchanges(user_id):
         Get all exchanges where the user has been a demander
     """
     try:
-        user_exchanges = Exchange.query.filter_by(
-            demander_id=user_id).all()
+        page = request.args.get('page', 1, type=int)
+        per_page = request.args.get('per_page', 20, type=int)
 
-        return success([e.to_dict() for e in user_exchanges])
+        pagination = paginate_query(
+            Exchange.query.filter_by(demander_id=user_id).order_by(Exchange.id.desc()),
+            page, per_page
+        )
+        return paginated_success([e.to_dict() for e in pagination.items], pagination)
 
     except SQLAlchemyError as e:
         db.session.rollback()
@@ -161,12 +174,17 @@ def get_exchanges_by_user(user_id):
         Get all exchanges in which a user participates
     """
     try:
-        user_exchanges = Exchange.query.filter(
-            (Exchange.offerer_id == user_id) |
-            (Exchange.demander_id == user_id)
-        ).all()
+        page = request.args.get('page', 1, type=int)
+        per_page = request.args.get('per_page', 20, type=int)
 
-        return success([e.to_dict() for e in user_exchanges])
+        pagination = paginate_query(
+            Exchange.query.filter(
+                (Exchange.offerer_id == user_id) |
+                (Exchange.demander_id == user_id)
+            ).order_by(Exchange.id.desc()),
+            page, per_page
+        )
+        return paginated_success([e.to_dict() for e in pagination.items], pagination)
 
     except SQLAlchemyError as e:
         db.session.rollback()

--- a/back/urls/message.py
+++ b/back/urls/message.py
@@ -55,7 +55,7 @@ def get_message(message_id):
         Get a single message
     """
     try:
-        msg = Message.query.get_or_404(message_id)
+        msg = db.get_or_404(Message, message_id)
         return success(msg.to_dict())
 
     except SQLAlchemyError as e:
@@ -110,7 +110,7 @@ def update_message(message_id):
     data = request.get_json() or {}
 
     try:
-        msg = Message.query.get_or_404(message_id)
+        msg = db.get_or_404(Message, message_id)
 
         current = get_current_user()
         if not current or current.id != msg.sender_id:
@@ -145,7 +145,7 @@ def delete_message(message_id):
         Delete a message
     """
     try:
-        msg = Message.query.get(message_id)
+        msg = db.session.get(Message, message_id)
 
         if not msg:
             return not_found("Message")

--- a/back/urls/message.py
+++ b/back/urls/message.py
@@ -5,7 +5,8 @@ from flask import Blueprint, request
 from flask_jwt_extended import jwt_required
 from back.models import db, Message
 from back.utils import (get_current_user, error_response, validate, success,
-                        forbidden, bad_request, not_found)
+                        forbidden, bad_request, not_found,
+                        paginate_query, paginated_success)
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 
 messages = Blueprint('messages', __name__)
@@ -17,13 +18,15 @@ def get_sent_messages(user_id):
         List messages sent by the user
     """
     try:
-        msgs = (
-            Message.query
-            .filter_by(sender_id=user_id)
-            .order_by(Message.sent_at.desc())
-            .all()
+        page = request.args.get('page', 1, type=int)
+        per_page = request.args.get('per_page', 20, type=int)
+
+        pagination = paginate_query(
+            Message.query.filter_by(sender_id=user_id)
+            .order_by(Message.sent_at.desc()),
+            page, per_page
         )
-        return success([m.to_dict() for m in msgs])
+        return paginated_success([m.to_dict() for m in pagination.items], pagination)
 
     except SQLAlchemyError as e:
         db.session.rollback()
@@ -36,13 +39,15 @@ def get_received_messages(user_id):
         List messages received by the user
     """
     try:
-        msgs = (
-            Message.query
-            .filter_by(receiver_id=user_id)
-            .order_by(Message.sent_at.desc())
-            .all()
+        page = request.args.get('page', 1, type=int)
+        per_page = request.args.get('per_page', 20, type=int)
+
+        pagination = paginate_query(
+            Message.query.filter_by(receiver_id=user_id)
+            .order_by(Message.sent_at.desc()),
+            page, per_page
         )
-        return success([m.to_dict() for m in msgs])
+        return paginated_success([m.to_dict() for m in pagination.items], pagination)
 
     except SQLAlchemyError as e:
         db.session.rollback()

--- a/back/urls/rating.py
+++ b/back/urls/rating.py
@@ -32,7 +32,7 @@ def get_rating(rating_id):
         Get a single rating
     """
     try:
-        rating = Rating.query.get(rating_id)
+        rating = db.session.get(Rating, rating_id)
 
         if not rating:
             return not_found("Rating")
@@ -65,8 +65,8 @@ def create_rating():
 
     try:
 
-        exchange = Exchange.query.get_or_404(data["exchange_id"])
-        rater = User.query.get_or_404(data["rater_id"])
+        exchange = db.get_or_404(Exchange, data["exchange_id"])
+        rater = db.get_or_404(User, data["rater_id"])
 
         if rater.id == exchange.offerer_id:
             rated_id = exchange.demander_id
@@ -76,7 +76,7 @@ def create_rating():
         if not rated_id:
             return bad_request("The exchange does not have a demander assigned yet")
 
-        rated = User.query.get_or_404(rated_id)
+        rated = db.get_or_404(User, rated_id)
 
         rating = Rating(
             exchange_id=exchange.id,
@@ -110,7 +110,7 @@ def update_rating(rating_id):
     data = request.get_json() or {}
 
     try:
-        rating = Rating.query.get(rating_id)
+        rating = db.session.get(Rating, rating_id)
 
         if not rating:
             return not_found("Rating")
@@ -149,7 +149,7 @@ def delete_rating(rating_id):
         Delete a rating
     """
     try:
-        rating = Rating.query.get(rating_id)
+        rating = db.session.get(Rating, rating_id)
 
         if not rating:
             return not_found("Rating")

--- a/back/urls/rating.py
+++ b/back/urls/rating.py
@@ -5,7 +5,8 @@ from flask import Blueprint, request
 from flask_jwt_extended import jwt_required
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from back.utils import (get_current_user, error_response, validate, success,
-                        forbidden, bad_request, not_found)
+                        forbidden, bad_request, not_found,
+                        paginate_query, paginated_success)
 from back.models import db, User, Rating, Exchange
 
 ratings = Blueprint('ratings', __name__)
@@ -17,9 +18,13 @@ def get_ratings():
         List all ratings
     """
     try:
-        all_ratings = Rating.query.all()
+        page = request.args.get('page', 1, type=int)
+        per_page = request.args.get('per_page', 20, type=int)
 
-        return success([r.to_dict() for r in all_ratings])
+        pagination = paginate_query(
+            Rating.query.order_by(Rating.id.desc()), page, per_page
+        )
+        return paginated_success([r.to_dict() for r in pagination.items], pagination)
 
     except SQLAlchemyError as e:
         db.session.rollback()

--- a/back/urls/skill.py
+++ b/back/urls/skill.py
@@ -33,7 +33,7 @@ def get_skill(skill_id):
     """
         Get a single skill
     """
-    skill = Skill.query.get_or_404(skill_id)
+    skill = db.get_or_404(Skill, skill_id)
     return success(skill.to_dict())
 
 
@@ -54,7 +54,7 @@ def create_skill():
 
     new_skill = Skill(
         name=data["name"],
-        description=data["description"],
+        description=data.get("description"),
         category_id=data["category_id"]
     )
 
@@ -73,7 +73,7 @@ def delete_skill(skill_id):
     """
         Delete a skill
     """
-    skill = Skill.query.get_or_404(skill_id)
+    skill = db.get_or_404(Skill, skill_id)
     db.session.delete(skill)
     db.session.commit()
     return success(message="Skill deleted")
@@ -85,7 +85,7 @@ def update_skill(skill_id):
     """
         Update a skill
     """
-    skill = Skill.query.get_or_404(skill_id)
+    skill = db.get_or_404(Skill, skill_id)
     data = request.get_json()
 
     skill.description = data.get('description', skill.description)

--- a/back/urls/user.py
+++ b/back/urls/user.py
@@ -12,7 +12,8 @@ from google.oauth2 import id_token as google_id_token
 from google.auth.transport import requests as google_requests
 from back.models import db, User, Skill, Category, Rating
 from back.utils import (get_current_user, error_response, validate, success,
-                        forbidden, bad_request, not_found)
+                        forbidden, bad_request, not_found,
+                        paginate_query, paginated_success)
 
 users = Blueprint('users', __name__)
 
@@ -23,21 +24,29 @@ def get_users():
         Get all users
     """
     try:
-        all_users = User.query.all()
+        page = request.args.get('page', 1, type=int)
+        per_page = request.args.get('per_page', 20, type=int)
 
+        pagination = paginate_query(
+            User.query.order_by(User.id), page, per_page
+        )
+
+        user_ids = [u.id for u in pagination.items]
         avg_rows = (
             db.session.query(
                 Rating.rated_id,
                 func.avg(Rating.score).label("avg")
             )
+            .filter(Rating.rated_id.in_(user_ids))
             .group_by(Rating.rated_id)
             .all()
         )
         avg_map = {row.rated_id: row.avg for row in avg_rows}
 
-        return success([
-            u.to_dict(rating_avg=avg_map.get(u.id, 0)) for u in all_users
-        ])
+        return paginated_success(
+            [u.to_dict(rating_avg=avg_map.get(u.id, 0)) for u in pagination.items],
+            pagination
+        )
 
     except SQLAlchemyError as e:
         db.session.rollback()
@@ -70,20 +79,23 @@ def get_users_by_category(category_id):
         Returns all users that have skills in a given category
     """
     category = db.get_or_404(Category, category_id)
-
     skill_ids = [s.id for s in category.skills]
 
-    if not skill_ids:
-        return success([])
+    page = request.args.get('page', 1, type=int)
+    per_page = request.args.get('per_page', 20, type=int)
 
-    category_users = (
-        User.query
-        .join(User.skills)
-        .filter(Skill.id.in_(skill_ids))
-        .all()
+    if not skill_ids:
+        return jsonify({"data": [], "pagination": {
+            "page": 1, "per_page": per_page, "total": 0,
+            "pages": 0, "has_next": False, "has_prev": False,
+        }}), 200
+
+    pagination = paginate_query(
+        User.query.join(User.skills).filter(Skill.id.in_(skill_ids)).order_by(User.id),
+        page, per_page
     )
 
-    user_ids = [u.id for u in category_users]
+    user_ids = [u.id for u in pagination.items]
     avg_rows = (
         db.session.query(
             Rating.rated_id,
@@ -95,9 +107,10 @@ def get_users_by_category(category_id):
     )
     avg_map = {row.rated_id: row.avg for row in avg_rows}
 
-    return success([
-        u.to_dict(rating_avg=avg_map.get(u.id, 0)) for u in category_users
-    ])
+    return paginated_success(
+        [u.to_dict(rating_avg=avg_map.get(u.id, 0)) for u in pagination.items],
+        pagination
+    )
 
 
 @users.route('/api/users/<int:user_id>', methods=['DELETE'])

--- a/back/urls/user.py
+++ b/back/urls/user.py
@@ -50,7 +50,7 @@ def get_user(user_id):
         Get a single user
     """
     try:
-        user = User.query.get(user_id)
+        user = db.session.get(User, user_id)
 
         if not user:
             return not_found("User")
@@ -69,7 +69,7 @@ def get_users_by_category(category_id):
     """
         Returns all users that have skills in a given category
     """
-    category = Category.query.get_or_404(category_id)
+    category = db.get_or_404(Category, category_id)
 
     skill_ids = [s.id for s in category.skills]
 
@@ -110,7 +110,7 @@ def delete_user(user_id):
     if not current or current.id != user_id:
         return forbidden()
 
-    user = User.query.get(user_id)
+    user = db.session.get(User, user_id)
     if not user:
         return not_found("User")
 
@@ -161,7 +161,7 @@ def create_user():
                     setattr(usr, f, datetime.strptime(
                         data[f], "%Y-%m-%d").date())
                 elif f == "skill_id":
-                    skill = Skill.query.get(data[f])
+                    skill = db.session.get(Skill, data[f])
                     if skill:
                         usr.skills.append(skill)
                 else:
@@ -201,7 +201,7 @@ def update_user(user_id):
         return bad_request(errors[0])
 
     try:
-        user = User.query.get_or_404(user_id)
+        user = db.get_or_404(User, user_id)
 
         fields = [
             "first_name", "last_name", "email",
@@ -241,9 +241,9 @@ def update_user_skill(user_id):
 
     data = request.get_json() or {}
     try:
-        usr = User.query.get(user_id)
+        usr = db.session.get(User, user_id)
         skill_id = data.get("associate") or data.get("disassociate")
-        skill = Skill.query.get(skill_id)
+        skill = db.session.get(Skill, skill_id)
 
         if not usr or not skill:
             return not_found("User or Skill")

--- a/back/utils.py
+++ b/back/utils.py
@@ -92,6 +92,31 @@ def success(data=None, message=None, status=200):
     return jsonify(body), status
 
 
+def paginate_query(query, page, per_page, max_per_page=100):
+    """Paginate a SQLAlchemy query. Clamps page ≥ 1 and per_page to [1, max_per_page]."""
+    try:
+        page = max(1, int(page))
+        per_page = min(max(1, int(per_page)), max_per_page)
+    except (TypeError, ValueError):
+        page, per_page = 1, 20
+    return query.paginate(page=page, per_page=per_page, error_out=False)
+
+
+def paginated_success(items_dicts, pagination):
+    """Return a paginated success response with metadata."""
+    return jsonify({
+        "data": items_dicts,
+        "pagination": {
+            "page": pagination.page,
+            "per_page": pagination.per_page,
+            "total": pagination.total,
+            "pages": pagination.pages,
+            "has_next": pagination.has_next,
+            "has_prev": pagination.has_prev,
+        }
+    }), 200
+
+
 def not_found(resource="Resource"):
     """Return a standardised 404 response."""
     return jsonify({"error": f"{resource} not found"}), 404

--- a/front/assets/components/ChatModal.jsx
+++ b/front/assets/components/ChatModal.jsx
@@ -29,7 +29,7 @@ export default function ChatModal({ show, close, receiverId }) {
       headers: { Authorization: `Bearer ${token}`, Accept: "application/json" },
     })
       .then((r) => (r.ok ? r.json() : Promise.reject()))
-      .then(setMe)
+      .then((d) => setMe(d.data || d))
       .catch(console.error);
   }, [show]);
 
@@ -48,10 +48,11 @@ export default function ChatModal({ show, close, receiverId }) {
         const snt = await r2.json();
 
         // --- fetch users ---
-        const usersResp = await fetch(`${env.api}/api/users`);
-        const users = await usersResp.json();
+        const usersResp = await fetch(`${env.api}/api/users?per_page=100`);
+        const usersJson = await usersResp.json();
+        const userList = usersJson.data || [];
         const userMap = new Map(
-          users.map((u) => [u.id, `${u.first_name} ${u.last_name}`])
+          userList.map((u) => [u.id, `${u.first_name} ${u.last_name}`])
         );
         setNames(userMap);
 
@@ -64,8 +65,10 @@ export default function ChatModal({ show, close, receiverId }) {
             userMap.get(m.receiver_id) || `Usuario ${m.receiver_id}`,
         });
 
-        setReceived(Array.isArray(rec) ? rec.map(process) : []);
-        setSent(Array.isArray(snt) ? snt.map(process) : []);
+        const recList = rec.data || [];
+        const sntList = snt.data || [];
+        setReceived(recList.map(process));
+        setSent(sntList.map(process));
       } catch (e) {
         console.error("Error cargando mensajes:", e);
       }
@@ -127,7 +130,8 @@ export default function ChatModal({ show, close, receiverId }) {
         body: JSON.stringify(body),
       });
       if (!res.ok) throw new Error("No se pudo enviar");
-      const newMsg = await res.json();
+      const newMsgJson = await res.json();
+      const newMsg = newMsgJson.data || newMsgJson;
 
       // reflect in UI
       setSent((prev) => [

--- a/front/assets/components/Navbar.jsx
+++ b/front/assets/components/Navbar.jsx
@@ -49,8 +49,8 @@ function Navbar() {
         const response = await fetch(`${env.api}/api/categories`);
         if (!response.ok) throw new Error("Error al obtener categorías");
         const data = await response.json();
-        setCategories(data);
-        dispatch({ type: "SET_CATEGORIES", payload: data });
+        setCategories(data.data || []);
+        dispatch({ type: "SET_CATEGORIES", payload: data.data });
       } catch (error) {
         console.error("Error cargando categorías:", error);
       }

--- a/front/pages/CategoryUsers.jsx
+++ b/front/pages/CategoryUsers.jsx
@@ -24,7 +24,8 @@ function CategoryUsers() {
     ])
 
       .then(([usersData, categoryData]) => {
-        setUsers(usersData), setCategory(categoryData);
+        setUsers(usersData.data || []);
+        setCategory(categoryData.data || categoryData);
       })
       .catch((err) => {
         console.error("Error al cargar datos:", err);

--- a/front/pages/Home.jsx
+++ b/front/pages/Home.jsx
@@ -33,9 +33,9 @@ function Home() {
           return res.json();
         })
         .then((data) => {
-          if (data) {
-            setUser(data);
-            dispatch({ type: "SET_USER", payload: data });
+          if (data?.data) {
+            setUser(data.data);
+            dispatch({ type: "SET_USER", payload: data.data });
           }
         })
         .catch((err) => console.error("Error al cargar usuario:", err));
@@ -45,8 +45,8 @@ function Home() {
     fetch(`${env.api}/api/users`)
       .then((res) => res.json())
       .then((data) => {
-        if (data) {
-          dispatch({ type: "SET_USERS", payload: data });
+        if (data?.data) {
+          dispatch({ type: "SET_USERS", payload: data.data });
         }
       })
       .catch((err) => console.error("Error al cargar usuarios:", err));
@@ -64,7 +64,7 @@ function Home() {
   useEffect(() => {
     fetch(`${env.api}/api/users`)
       .then((res) => res.json())
-      .then((data) => setUsers(data.slice(0, 8)))
+      .then((data) => setUsers((data.data || []).slice(0, 8)))
       .catch((err) => console.error("Error al cargar usuarios:", err));
   }, []);
 

--- a/front/pages/PublicProfile.jsx
+++ b/front/pages/PublicProfile.jsx
@@ -36,7 +36,7 @@ import { env } from "../environ";
         });
         if (!res.ok) return null;
         const data = await res.json();
-        return data;
+        return data.data || data;
       } catch (err) {
         console.error("Error obteniendo usuario actual:", err);
         return null;
@@ -54,7 +54,7 @@ import { env } from "../environ";
           const res = await fetch(`${env.api}/api/users/${userId}`);
           if (!res.ok) throw new Error("Error al obtener usuario");
           const data = await res.json();
-          setUser(data);
+          setUser(data.data || data);
         } catch (err) {
           console.error(err);
           setError("No se pudo cargar el perfil del usuario.");
@@ -93,7 +93,7 @@ import { env } from "../environ";
           if (!res.ok) throw new Error(`HTTP ${res.status}: ${text}`);
 
           const data = JSON.parse(text);
-          setExchanges(Array.isArray(data) ? data : []);
+          setExchanges(Array.isArray(data.data) ? data.data : []);
         } catch (err) {
           console.error("Error al cargar intercambios:", err);
           setExchanges([]);

--- a/front/pages/UserProfile.jsx
+++ b/front/pages/UserProfile.jsx
@@ -149,8 +149,8 @@ const handleSave = async () => {
     const data = await resp.json();
 
     // Update state
-    setUser(data?.updated ?? user);
-    dispatch({ type: "SET_USER", payload: data?.updated ?? user });
+    setUser(data?.data ?? user);
+    dispatch({ type: "SET_USER", payload: data?.data ?? user });
     setEditing(false);
     setMsg({ tipo: "success", contenido: data?.message || "Cambios guardados correctamente." });
   } catch (e) {
@@ -203,7 +203,7 @@ const handleRemoveSkill = async (skillId) => {
     if (!ref.ok) throw new Error("Error al refrescar usuario");
     const data = await ref.json();
 
-    setUser(data);
+    setUser(data.data || data);
     setMsg({
       tipo: "success",
       contenido: "Habilidad eliminada correctamente.",
@@ -237,7 +237,8 @@ const fetchUserById = async (id) => {
       headers: { Accept: "application/json" },
     });
     if (!r.ok) return null;
-    return await r.json();
+    const data = await r.json();
+    return data.data || data;
   } catch {
     return null;
   }
@@ -255,7 +256,7 @@ const fetchExchanges = async () => {
     if (!res.ok) throw new Error("Error al obtener intercambios");
 
     const raw = await res.json();
-    const list = Array.isArray(raw) ? raw : [];
+    const list = Array.isArray(raw?.data) ? raw.data : [];
 
     // collect unique user ids to minimize calls
     const ids = new Set();
@@ -444,7 +445,7 @@ const openRatingModal = (exchange) => {
                   // refresh to get updated descriptions from backend
                   fetch(`${env.api}/api/users/${user.id}`)
                     .then((r) => r.json())
-                    .then((d) => setUser(d))
+                    .then((d) => setUser(d.data || d))
                     .catch((e) => console.error("Error refrescando usuario:", e));
                 }}
               >
@@ -715,7 +716,7 @@ const openRatingModal = (exchange) => {
                         // refresh user to see new skill
                         fetch(`${env.api}/api/users/${user.id}`)
                           .then((r) => r.json())
-                          .then((d) => setUser(d))
+                          .then((d) => setUser(d.data || d))
                           .catch((e) => console.error("Error al actualizar habilidades:", e));
                       }}
                     />
@@ -837,13 +838,14 @@ const openRatingModal = (exchange) => {
               });
 
               const data = await res.json();
+              const picUrl = data?.data?.profile_picture || data?.profile_picture;
               if (res.ok) {
                 setUser((prev) => ({
                   ...prev,
-                  profile_picture: data.profile_picture,
+                  profile_picture: picUrl,
                 }));
                 const img = document.querySelector(".perfil-avatar");
-                if (img) img.src = data.profile_picture;
+                if (img) img.src = picUrl;
                 setMsg({
                   tipo: "success",
                   contenido: "Foto actualizada correctamente",


### PR DESCRIPTION
## Summary

- Added `paginate_query()` and `paginated_success()` helpers to `back/utils.py`
- Paginated 9 list endpoints: `GET /api/users`, `GET /api/users/category/<id>`, `GET /api/messages/<id>/sent`, `GET /api/messages/<id>/received`, `GET /api/exchanges` (all 4 variants), `GET /api/ratings`
- Response format: `{"data": [...], "pagination": {"page", "per_page", "total", "pages", "has_next", "has_prev"}}`; defaults `page=1`, `per_page=20`, max 100
- Added 5 pagination tests (125 total, all passing)
- Frontend: fixed `.data` unwrapping across `ChatModal`, `Navbar`, `Home`, `CategoryUsers`, `PublicProfile`, `UserProfile` (fixes pre-existing data-access bugs)

## Test plan

- [ ] `docker compose exec backend pytest` — all 125 tests pass
- [ ] `GET /api/users?page=1&per_page=5` returns 5 users + pagination metadata
- [ ] `GET /api/exchanges?page=2&per_page=10` returns correct page
- [ ] Home page shows user cards (previously broken due to `.data` unwrapping)
- [ ] ChatModal loads conversations correctly
- [ ] CategoryUsers page renders users for a category