### PR TITLE
feat: add frontend error boundary (#15)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,7 @@ All API endpoints prefixed with `/api/`. Auth uses JWT tokens via Flask-JWT-Exte
 - **State management**: Context + useReducer in `front/store.js` (actions: SET_USER, SET_USERS, SET_TOKEN, SET_CATEGORIES)
 - **API calls**: `front/services/api.js`
 - **Pages**: Home, Login, Register, UserProfile, PublicProfile, CategoryUsers
-- **Components**: Navbar, Footer, Carousel, UserCard, ChatModal, ExchangeModal, RatingModal, AddSkillModal, CropperModal, MessagingButton
+- **Components**: Navbar, Footer, Carousel, UserCard, ChatModal, ExchangeModal, RatingModal, AddSkillModal, CropperModal, MessagingButton, ErrorBoundary
 - **Styles**: `front/assets/styles/` — one CSS file per component
 
 ### Key Patterns

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -99,9 +99,11 @@ Roadmap of improvements based on code analysis. Organized by priority.
   - Added 5 pagination tests across test_users, test_messages, test_exchanges, test_ratings
   - Frontend updated to read `.data` from all list responses (fixes pre-existing data-unwrapping bugs)
 
-- [ ] **Add frontend error boundary** [#15](https://github.com/jemartnz/swapp/issues/15)
-  - Catch React rendering errors gracefully
-  - Show user-friendly error page instead of white screen
+- [x] **Add frontend error boundary** [#15](https://github.com/jemartnz/swapp/issues/15)
+  - Created `front/assets/components/ErrorBoundary.jsx` — class component with `getDerivedStateFromError` + `componentDidCatch`
+  - Fallback UI in Spanish: "Algo salió mal" with "Reintentar" and "Volver al inicio" buttons
+  - Per-route boundaries in `App.jsx` (scoped: only the erroring page falls back)
+  - Global boundary in `main.jsx` (catches errors in providers/routing infrastructure)
 
 - [ ] **Improve Vite proxy setup** [#16](https://github.com/jemartnz/swapp/issues/16)
   - Configure Vite `server.proxy` to forward `/api` requests to the backend

--- a/front/App.jsx
+++ b/front/App.jsx
@@ -8,20 +8,21 @@ import Login from "./pages/Login";
 import UserProfile from "./pages/UserProfile";
 import PublicProfile from "./pages/PublicProfile";
 import CategoryUsers from "./pages/CategoryUsers.jsx";
+import ErrorBoundary from "./assets/components/ErrorBoundary";
 
 export default function App() {
   return (
     <StoreProvider>
       <Routes>
-        <Route path="/" element={<Home />} />
-        <Route path="/registro" element={<Register />} />
-        <Route path="/login" element={<Login />} />
-        <Route path="/perfil" element={<UserProfile />} />
-        <Route path="/usuario/:userId" element={<PublicProfile />} />
+        <Route path="/" element={<ErrorBoundary><Home /></ErrorBoundary>} />
+        <Route path="/registro" element={<ErrorBoundary><Register /></ErrorBoundary>} />
+        <Route path="/login" element={<ErrorBoundary><Login /></ErrorBoundary>} />
+        <Route path="/perfil" element={<ErrorBoundary><UserProfile /></ErrorBoundary>} />
+        <Route path="/usuario/:userId" element={<ErrorBoundary><PublicProfile /></ErrorBoundary>} />
         <Route
           path="/usuarios/categoria/:categoryId"
-          element={<CategoryUsers />}
-        ></Route>
+          element={<ErrorBoundary><CategoryUsers /></ErrorBoundary>}
+        />
       </Routes>
     </StoreProvider>
   );

--- a/front/assets/components/ErrorBoundary.jsx
+++ b/front/assets/components/ErrorBoundary.jsx
@@ -1,0 +1,54 @@
+import React from "react";
+import "../styles/ErrorBoundary.css";
+
+export default class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+    this.handleReset = this.handleReset.bind(this);
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error, info) {
+    console.error("ErrorBoundary caught an error:", error, info.componentStack);
+  }
+
+  handleReset() {
+    this.setState({ hasError: false });
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="error-boundary d-flex flex-column align-items-center justify-content-center min-vh-100 text-center px-3">
+          <div className="error-boundary__box">
+            <div className="error-boundary__icon">⚠️</div>
+            <h1 className="error-boundary__title">Algo salió mal</h1>
+            <p className="error-boundary__message">
+              Ocurrió un error inesperado. Puedes intentar de nuevo o volver al
+              inicio.
+            </p>
+            <div className="d-flex gap-3 justify-content-center mt-4">
+              <button
+                className="btn btn-outline-secondary"
+                onClick={this.handleReset}
+              >
+                Reintentar
+              </button>
+              <button
+                className="btn btn-naranja fw-semibold"
+                onClick={() => window.location.replace("/")}
+              >
+                Volver al inicio
+              </button>
+            </div>
+          </div>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/front/assets/styles/ErrorBoundary.css
+++ b/front/assets/styles/ErrorBoundary.css
@@ -1,0 +1,29 @@
+.error-boundary {
+  background-color: #f8f9fa;
+}
+
+.error-boundary__box {
+  max-width: 480px;
+  padding: 3rem 2rem;
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.08);
+}
+
+.error-boundary__icon {
+  font-size: 3.5rem;
+  margin-bottom: 1rem;
+}
+
+.error-boundary__title {
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: #ff7517;
+  margin-bottom: 0.75rem;
+}
+
+.error-boundary__message {
+  color: #6c757d;
+  font-size: 1rem;
+  line-height: 1.6;
+}

--- a/front/main.jsx
+++ b/front/main.jsx
@@ -5,12 +5,15 @@ import { GoogleOAuthProvider } from "@react-oauth/google";
 import { env } from "./environ";
 import "./index.css";
 import App from "./App.jsx";
+import ErrorBoundary from "./assets/components/ErrorBoundary";
 
 createRoot(document.querySelector("#root")).render(
   <StrictMode>
     <GoogleOAuthProvider clientId={env.googleClientId}>
       <BrowserRouter>
-        <App />
+        <ErrorBoundary>
+          <App />
+        </ErrorBoundary>
       </BrowserRouter>
     </GoogleOAuthProvider>
   </StrictMode>


### PR DESCRIPTION
## Summary

- New `ErrorBoundary` class component (`getDerivedStateFromError` + `componentDidCatch`)
- Fallback UI in Spanish: "Algo salió mal" with **Reintentar** and **Volver al inicio** buttons, styled with Swapp orange branding
- Per-route boundaries in `App.jsx` — only the erroring page falls back, other routes stay functional
- Global boundary in `main.jsx` — catches errors in providers or routing infrastructure

## Test plan

- [ ] Verify app loads normally (boundaries are transparent when no error)
- [ ] Temporarily throw in a component to confirm fallback UI appears instead of white screen
- [ ] Confirm "Reintentar" button resets the boundary and re-renders the page
- [ ] Confirm "Volver al inicio" navigates to `/`